### PR TITLE
[feat] #9 response, controllerAdvice 구현

### DIFF
--- a/src/main/java/com/kuit/findyou/domain/auth/TestController.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/TestController.java
@@ -1,5 +1,7 @@
 package com.kuit.findyou.domain.auth;
 
+import com.kuit.findyou.global.common.exception.BadRequestException;
+import com.kuit.findyou.global.common.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -8,7 +10,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class TestController {
     @Operation(summary = "테스트", description = "테스트")
     @GetMapping("test")
-    public String hello(){
-        return "hello";
+    public BaseResponse<String> hello(){
+        return new BaseResponse<>("hello");
+    }
+
+    @GetMapping("test/error")
+    public BaseResponse<String> testControllerAdvice(){
+//        if(true) throw new BadRequestException(BAD_REQUEST);
+        if(true) throw new IllegalArgumentException();
+        return new BaseResponse<>("hello");
     }
 }

--- a/src/main/java/com/kuit/findyou/global/common/exception/BadRequestException.java
+++ b/src/main/java/com/kuit/findyou/global/common/exception/BadRequestException.java
@@ -1,0 +1,15 @@
+package com.kuit.findyou.global.common.exception;
+
+import com.kuit.findyou.global.common.response.status.ResponseStatus;
+import lombok.Getter;
+
+@Getter
+public class BadRequestException extends RuntimeException {
+
+    private final ResponseStatus exceptionStatus;
+
+    public BadRequestException(ResponseStatus exceptionStatus) {
+        super(exceptionStatus.getMessage());
+        this.exceptionStatus = exceptionStatus;
+    }
+}

--- a/src/main/java/com/kuit/findyou/global/common/exception_handler/GlobalControllerAdvice.java
+++ b/src/main/java/com/kuit/findyou/global/common/exception_handler/GlobalControllerAdvice.java
@@ -1,0 +1,41 @@
+package com.kuit.findyou.global.common.exception_handler;
+
+import com.kuit.findyou.global.common.exception.BadRequestException;
+import com.kuit.findyou.global.common.response.BaseErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.TypeMismatchException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.*;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalControllerAdvice {
+    // 잘못된 요청일 경우
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler({BadRequestException.class, TypeMismatchException.class})
+    public BaseErrorResponse handle_BadRequest(Exception e){
+        log.error("[handle_BadRequest]", e);
+        return new BaseErrorResponse(BAD_REQUEST);
+    }
+
+    // 요청한 api가 없을 경우
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public BaseErrorResponse handle_NoHandlerFoundException(Exception e){
+        log.error("[handle_NoHandlerFoundException]", e);
+        return new BaseErrorResponse(NOT_FOUND);
+    }
+
+    // 런타임 오류가 발생한 경우
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(RuntimeException.class)
+    public BaseErrorResponse handle_RuntimeException(Exception e) {
+        log.error("[handle_RuntimeException]", e);
+        return new BaseErrorResponse(INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/com/kuit/findyou/global/common/response/BaseErrorResponse.java
+++ b/src/main/java/com/kuit/findyou/global/common/response/BaseErrorResponse.java
@@ -1,0 +1,43 @@
+package com.kuit.findyou.global.common.response;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.kuit.findyou.global.common.response.status.ResponseStatus;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@JsonPropertyOrder({"success", "code", "message", "timestamp"})
+public class BaseErrorResponse implements ResponseStatus {
+    private final boolean success;
+    private final int code;
+    private final String message;
+    private final LocalDateTime timestamp;
+
+    public BaseErrorResponse(ResponseStatus status) {
+        this.success = false;
+        this.code = status.getCode();
+        this.message = status.getMessage();
+        this.timestamp = LocalDateTime.now();
+    }
+
+    public BaseErrorResponse(ResponseStatus status, String message) {
+        this.success = false;
+        this.code = status.getCode();
+        this.message = message;
+        this.timestamp = LocalDateTime.now();
+    }
+
+    @Override
+    public boolean getSuccess() {
+        return this.success;
+    }
+    @Override
+    public int getCode() {
+        return this.code;
+    }
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/kuit/findyou/global/common/response/BaseResponse.java
+++ b/src/main/java/com/kuit/findyou/global/common/response/BaseResponse.java
@@ -1,0 +1,38 @@
+package com.kuit.findyou.global.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.kuit.findyou.global.common.response.status.ResponseStatus;
+import lombok.Getter;
+
+import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.SUCCESS;
+
+@Getter
+@JsonPropertyOrder({"success", "code", "message", "data"})
+public class BaseResponse<T> implements ResponseStatus {
+    private final boolean success;
+    private final int code;
+    private final String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final T data;
+
+    public BaseResponse(T data) {
+        this.success = true;
+        this.code = SUCCESS.getCode();
+        this.message = SUCCESS.getMessage();
+        this.data = data;
+    }
+
+    @Override
+    public boolean getSuccess() {
+        return this.success;
+    }
+    @Override
+    public int getCode() {
+        return this.code;
+    }
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/kuit/findyou/global/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/kuit/findyou/global/common/response/status/BaseExceptionResponseStatus.java
@@ -1,0 +1,28 @@
+package com.kuit.findyou.global.common.response.status;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum BaseExceptionResponseStatus implements ResponseStatus{
+    SUCCESS(20000, "요청에 성공했습니다."),
+    BAD_REQUEST(40000, "유효하지 않은 요청입니다."),
+    NOT_FOUND(40400, "존재하지 않는 API입니다."),
+    INTERNAL_SERVER_ERROR(50000, "서버 내부 오류입니다.");
+
+    private final boolean success = false;
+    private final int code;
+    private final String message;
+
+    @Override
+    public boolean getSuccess() { return this.success; }
+
+    @Override
+    public int getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/kuit/findyou/global/common/response/status/ResponseStatus.java
+++ b/src/main/java/com/kuit/findyou/global/common/response/status/ResponseStatus.java
@@ -1,0 +1,10 @@
+package com.kuit.findyou.global.common.response.status;
+
+public interface ResponseStatus {
+    boolean getSuccess();
+
+    int getCode();
+
+    String getMessage();
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,12 @@ spring:
       local : local-db, dev-port
       dev: dev-db, dev-port
       prod: prod-db, prod-port
-    active: local
+    active: dev
+  mvc:
+    throw-exception-if-no-handler-found: true
+  web:
+    resources:
+      add-mappings: false
 ---
 # 로컬에서 사용하는 DB
 spring:


### PR DESCRIPTION
## Related issue 🛠
- closed #9 

## Work Description 📝
- 서버에서 공통적으로 사용될 정상 응답인 BaseResponse, 실패 응답인 BaseErrorResponse를 구현했습니다
- 전역적으로 예외를 처리하기 위해서 GlobalControllerAdvice를 구현했습니다
- 예외 발생 시 응답의 상태를 나타내는 열거형 BaseExceptionResponseStatus를 구현했습니다
- 커스텀 예외 BadRequestException을 구현했습니다

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
- 없습니다

## To Reviewers 📢
