### PR TITLE
[Feat] cascade 적용 및 중간 테이블 hard-delete로 변경

### DIFF
--- a/src/main/java/com/kuit/findyou/domain/auth/model/User.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/model/User.java
@@ -37,27 +37,33 @@ public class User extends BaseEntity {
     @Column(name = "profile_image_url")
     private String profileImageUrl;
 
-    @OneToMany(mappedBy = "user")
+
+    // 신고글에 대해 orphanRemoval = true 만 설정
+    @OneToMany(mappedBy = "user", orphanRemoval = true)
     @Builder.Default
     private List<Report> reports = new ArrayList<>();
 
     // 최근 본 신고글 과의 양방향 연관 관계 설정
-    @OneToMany(mappedBy = "user")
+    // 최근 본 신고글에 대해 orphanRemoval = true 만 설정
+    @OneToMany(mappedBy = "user", orphanRemoval = true)
     @Builder.Default
     private List<ViewedReport> viewedReports = new ArrayList<>();
 
     // 관심 신고글 과의 양방향 연관 관계 설정
-    @OneToMany(mappedBy = "user")
+    // 관심 신고글에 대해 orphanRemoval = true 만 설정
+    @OneToMany(mappedBy = "user", orphanRemoval = true)
     @Builder.Default
     private List<InterestReport> interestReports = new ArrayList<>();
 
     // 최근 본 보호글 과의 양방향 연관 관계 설정
-    @OneToMany(mappedBy = "user")
+    // 최근 본 보호글에 대해 orphanRemoval = true 만 설정
+    @OneToMany(mappedBy = "user", orphanRemoval = true)
     @Builder.Default
     private List<ViewedProtectingReport> viewedProtectingReports = new ArrayList<>();
 
     // 관심 보호글 과의 양방향 연관 관계 설정
-    @OneToMany(mappedBy = "user")
+    // 관심 보호글에 대해 orphanRemoval = true 만 설정
+    @OneToMany(mappedBy = "user", orphanRemoval = true)
     @Builder.Default
     private List<InterestProtectingReport> interestProtectingReports = new ArrayList<>();
 

--- a/src/main/java/com/kuit/findyou/domain/auth/model/User.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/model/User.java
@@ -37,7 +37,6 @@ public class User extends BaseEntity {
     @Column(name = "profile_image_url")
     private String profileImageUrl;
 
-
     // 신고글에 대해 orphanRemoval = true 만 설정
     @OneToMany(mappedBy = "user", orphanRemoval = true)
     @Builder.Default

--- a/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
+++ b/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
@@ -30,15 +30,15 @@ public class ReportController {
 
 
     // test에 필요한 레포지토리들
-    private final UserRepository userRepository;
-    private final ProtectingReportRepository protectingReportRepository;
-    private final InterestProtectingReportRepository interestProtectingReportRepository;
-    private final BreedRepository breedRepository;
-    private final AnimalFeatureRepository animalFeatureRepository;
-    private final ReportAnimalRepository reportAnimalRepository;
-    private final ReportedAnimalFeatureRepository reportedAnimalFeatureRepository;
-    private final ReportRepository reportRepository;
-    private final InterestReportRepository interestReportRepository;
+//    private final UserRepository userRepository;
+//    private final ProtectingReportRepository protectingReportRepository;
+//    private final InterestProtectingReportRepository interestProtectingReportRepository;
+//    private final BreedRepository breedRepository;
+//    private final AnimalFeatureRepository animalFeatureRepository;
+//    private final ReportAnimalRepository reportAnimalRepository;
+//    private final ReportedAnimalFeatureRepository reportedAnimalFeatureRepository;
+//    private final ReportRepository reportRepository;
+//    private final InterestReportRepository interestReportRepository;
 
 
     @GetMapping("/report-animals/{report_id}")
@@ -96,116 +96,116 @@ public class ReportController {
         return new BaseResponse<>(totalCardDTO);
     }
 
-    @PostConstruct
-    public void init() {
-        User user = User.builder()
-                .name("김상균")
-                .email("ksg001227@naver.com")
-                .password("skcjswo00")
-                .build();
-
-        userRepository.save(user);
-
-        //=========================================
-        // 품종, 축종 설정
-        Breed breed = Breed.builder()
-                .name("시츄")
-                .species("개")
-                .build();
-        breedRepository.save(breed);
-        //=========================================
-
-        //=========================================
-        // 동물 특징 생성
-        AnimalFeature animalFeature = AnimalFeature.builder().featureValue("순해요").build();
-        AnimalFeature animalFeature2 = AnimalFeature.builder().featureValue("물어요").build();
-        animalFeatureRepository.save(animalFeature);
-        animalFeatureRepository.save(animalFeature2);
-        //=========================================
-
-
-        for (int i = 1; i <= 41; i++) {
-            ProtectingReport protectingReport = ProtectingReport.builder()
-                    .happenDate(LocalDate.now())
-                    .imageUrl(String.valueOf(i))
-                    .species(String.valueOf(i))
-                    .noticeNumber(String.valueOf(i))
-                    .noticeStartDate(LocalDate.now())
-                    .noticeEndDate(LocalDate.now())
-                    .breed(String.valueOf(i))
-                    .furColor(String.valueOf(i))
-                    .weight(3.5F)
-                    .age((short) i)
-                    .sex(Sex.M)
-                    .neutering(Neutering.N)
-                    .foundLocation(String.valueOf(i))
-                    .significant(String.valueOf(i))
-                    .careName(String.valueOf(i))
-                    .careAddr(String.valueOf(i))
-                    .careTel(String.valueOf(i))
-                    .authority(String.valueOf(i))
-                    .authorityPhoneNumber(String.valueOf(i))
-                    .build();
-            protectingReportRepository.save(protectingReport);
-
-            if (i > 4 && i < 15) {
-                InterestProtectingReport interestProtectingReport = InterestProtectingReport.createInterestProtectingReport(user, protectingReport);
-                interestProtectingReportRepository.save(interestProtectingReport);
-            }
-
-            if (i > 24 && i < 35) {
-                InterestProtectingReport interestProtectingReport = InterestProtectingReport.createInterestProtectingReport(user, protectingReport);
-                interestProtectingReportRepository.save(interestProtectingReport);
-            }
-        }
-
-        for(int i=1;i<=67;i++) {
-            // 신고 동물 설정
-            ReportAnimal reportAnimal = ReportAnimal.builder()
-                    .furColor(String.valueOf(i))
-                    .breed(breed)
-                    .build();
-            reportAnimalRepository.save(reportAnimal);
-            //=========================================
-
-
-            //=========================================
-            // 신고 동물에 특징 매핑
-            ReportedAnimalFeature reportedAnimalFeature = ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature);
-            ReportedAnimalFeature reportedAnimalFeature2 = ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature2);
-            reportedAnimalFeatureRepository.save(reportedAnimalFeature);
-            reportedAnimalFeatureRepository.save(reportedAnimalFeature2);
-
-            //=========================================
-            //이미지 객체 생성
-            Image image1 = Image.createImage("C:/images/cloud/1.jpg", UUID.randomUUID().toString());
-            Image image2 = Image.createImage("C:/images/cloud/2.jpg", UUID.randomUUID().toString());
-
-            List<Image> images = new ArrayList<>();
-            images.add(image1);
-            images.add(image2);
-            //=========================================
-
-            //=========================================
-            // 신고글 작성
-            String tag = "목격신고";
-            if (i > 20) {
-                tag = "실종신고";
-            }
-
-            Report report = Report.createReport(tag, String.valueOf(i), LocalDate.now(), String.valueOf(i), user, reportAnimal, images);
-            reportRepository.save(report);
-            //=========================================
-
-            //=========================================
-            // 관심 글로 등록
-            if (i > 20) {
-                InterestReport viewedReport = InterestReport.createInterestReport(user, report);
-                interestReportRepository.save(viewedReport);
-            }
-            //=========================================
-
-
-        }
-    }
+//    @PostConstruct
+//    public void init() {
+//        User user = User.builder()
+//                .name("김상균")
+//                .email("ksg001227@naver.com")
+//                .password("skcjswo00")
+//                .build();
+//
+//        userRepository.save(user);
+//
+//        //=========================================
+//        // 품종, 축종 설정
+//        Breed breed = Breed.builder()
+//                .name("시츄")
+//                .species("개")
+//                .build();
+//        breedRepository.save(breed);
+//        //=========================================
+//
+//        //=========================================
+//        // 동물 특징 생성
+//        AnimalFeature animalFeature = AnimalFeature.builder().featureValue("순해요").build();
+//        AnimalFeature animalFeature2 = AnimalFeature.builder().featureValue("물어요").build();
+//        animalFeatureRepository.save(animalFeature);
+//        animalFeatureRepository.save(animalFeature2);
+//        //=========================================
+//
+//
+//        for (int i = 1; i <= 41; i++) {
+//            ProtectingReport protectingReport = ProtectingReport.builder()
+//                    .happenDate(LocalDate.now())
+//                    .imageUrl(String.valueOf(i))
+//                    .species(String.valueOf(i))
+//                    .noticeNumber(String.valueOf(i))
+//                    .noticeStartDate(LocalDate.now())
+//                    .noticeEndDate(LocalDate.now())
+//                    .breed(String.valueOf(i))
+//                    .furColor(String.valueOf(i))
+//                    .weight(3.5F)
+//                    .age((short) i)
+//                    .sex(Sex.M)
+//                    .neutering(Neutering.N)
+//                    .foundLocation(String.valueOf(i))
+//                    .significant(String.valueOf(i))
+//                    .careName(String.valueOf(i))
+//                    .careAddr(String.valueOf(i))
+//                    .careTel(String.valueOf(i))
+//                    .authority(String.valueOf(i))
+//                    .authorityPhoneNumber(String.valueOf(i))
+//                    .build();
+//            protectingReportRepository.save(protectingReport);
+//
+//            if (i > 4 && i < 15) {
+//                InterestProtectingReport interestProtectingReport = InterestProtectingReport.createInterestProtectingReport(user, protectingReport);
+//                interestProtectingReportRepository.save(interestProtectingReport);
+//            }
+//
+//            if (i > 24 && i < 35) {
+//                InterestProtectingReport interestProtectingReport = InterestProtectingReport.createInterestProtectingReport(user, protectingReport);
+//                interestProtectingReportRepository.save(interestProtectingReport);
+//            }
+//        }
+//
+//        for(int i=1;i<=67;i++) {
+//            // 신고 동물 설정
+//            ReportAnimal reportAnimal = ReportAnimal.builder()
+//                    .furColor(String.valueOf(i))
+//                    .breed(breed)
+//                    .build();
+//            reportAnimalRepository.save(reportAnimal);
+//            //=========================================
+//
+//
+//            //=========================================
+//            // 신고 동물에 특징 매핑
+//            ReportedAnimalFeature reportedAnimalFeature = ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature);
+//            ReportedAnimalFeature reportedAnimalFeature2 = ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature2);
+//            reportedAnimalFeatureRepository.save(reportedAnimalFeature);
+//            reportedAnimalFeatureRepository.save(reportedAnimalFeature2);
+//
+//            //=========================================
+//            //이미지 객체 생성
+//            Image image1 = Image.createImage("C:/images/cloud/1.jpg", UUID.randomUUID().toString());
+//            Image image2 = Image.createImage("C:/images/cloud/2.jpg", UUID.randomUUID().toString());
+//
+//            List<Image> images = new ArrayList<>();
+//            images.add(image1);
+//            images.add(image2);
+//            //=========================================
+//
+//            //=========================================
+//            // 신고글 작성
+//            String tag = "목격신고";
+//            if (i > 20) {
+//                tag = "실종신고";
+//            }
+//
+//            Report report = Report.createReport(tag, String.valueOf(i), LocalDate.now(), String.valueOf(i), user, reportAnimal, images);
+//            reportRepository.save(report);
+//            //=========================================
+//
+//            //=========================================
+//            // 관심 글로 등록
+//            if (i > 20) {
+//                InterestReport viewedReport = InterestReport.createInterestReport(user, report);
+//                interestReportRepository.save(viewedReport);
+//            }
+//            //=========================================
+//
+//
+//        }
+//    }
 }

--- a/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
+++ b/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
@@ -35,8 +35,6 @@ public class ReportController {
 //    private final InterestProtectingReportRepository interestProtectingReportRepository;
 //    private final BreedRepository breedRepository;
 //    private final AnimalFeatureRepository animalFeatureRepository;
-//    private final ReportAnimalRepository reportAnimalRepository;
-//    private final ReportedAnimalFeatureRepository reportedAnimalFeatureRepository;
 //    private final ReportRepository reportRepository;
 //    private final InterestReportRepository interestReportRepository;
 
@@ -165,16 +163,13 @@ public class ReportController {
 //                    .furColor(String.valueOf(i))
 //                    .breed(breed)
 //                    .build();
-//            reportAnimalRepository.save(reportAnimal);
 //            //=========================================
 //
 //
 //            //=========================================
 //            // 신고 동물에 특징 매핑
-//            ReportedAnimalFeature reportedAnimalFeature = ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature);
-//            ReportedAnimalFeature reportedAnimalFeature2 = ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature2);
-//            reportedAnimalFeatureRepository.save(reportedAnimalFeature);
-//            reportedAnimalFeatureRepository.save(reportedAnimalFeature2);
+//            ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature);
+//            ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature2);
 //
 //            //=========================================
 //            //이미지 객체 생성

--- a/src/main/java/com/kuit/findyou/domain/report/dto/ProtectingReportInfoDTO.java
+++ b/src/main/java/com/kuit/findyou/domain/report/dto/ProtectingReportInfoDTO.java
@@ -1,6 +1,7 @@
 package com.kuit.findyou.domain.report.dto;
 
 import com.kuit.findyou.domain.auth.model.User;
+import com.kuit.findyou.domain.home.dto.ReportTag;
 import com.kuit.findyou.domain.report.model.ProtectingReport;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,7 +35,7 @@ public class ProtectingReportInfoDTO {
         return ProtectingReportInfoDTO.builder()
                 .imageUrl("image1.jpg")   // 더미 데이터 삽입
                 .breed(protectingReport.getBreed())
-                .tag("보호중")
+                .tag(ReportTag.PROTECTING.getValue())
                 .age(protectingReport.getAgeWithYear())
                 .weight(protectingReport.getWeightWithKg())
                 .sex(protectingReport.getAnimalSex())

--- a/src/main/java/com/kuit/findyou/domain/report/model/Image.java
+++ b/src/main/java/com/kuit/findyou/domain/report/model/Image.java
@@ -3,12 +3,18 @@ import com.kuit.findyou.domain.report.model.Report;
 import com.kuit.findyou.global.common.model.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 
 @Getter
 @Setter
 @Entity
 @Table(name = "report_image")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@SQLDelete(sql = "UPDATE report_image SET status = 'N' WHERE image_id = ?")
+@SQLRestriction("status = 'Y'")
 public class Image extends BaseEntity {
 
     @Id

--- a/src/main/java/com/kuit/findyou/domain/report/model/InterestProtectingReport.java
+++ b/src/main/java/com/kuit/findyou/domain/report/model/InterestProtectingReport.java
@@ -36,14 +36,20 @@ public class InterestProtectingReport extends BaseEntity {
     public static InterestProtectingReport createInterestProtectingReport(User user, ProtectingReport protectingReport) {
         InterestProtectingReport interestProtectingReport = new InterestProtectingReport();
         interestProtectingReport.setUser(user);
-        interestProtectingReport.protectingReport = protectingReport;
+        interestProtectingReport.setProtectingReport(protectingReport); // 연관 관계 편의 메서드 적용
         return interestProtectingReport;
     }
 
-    // 연관 관계 편의 메서드
+    // User 에 대한 연관 관계 편의 메서드
     private void setUser(User user) {
         this.user = user;
         user.addInterestProtectingReport(this);
+    }
+
+    // ProtectingReport 에 대한 연관 관계 편의 메서드
+    private void setProtectingReport(ProtectingReport protectingReport) {
+        this.protectingReport = protectingReport;
+        protectingReport.addInterestProtectingReport(this);
     }
 
 

--- a/src/main/java/com/kuit/findyou/domain/report/model/InterestProtectingReport.java
+++ b/src/main/java/com/kuit/findyou/domain/report/model/InterestProtectingReport.java
@@ -15,7 +15,6 @@ import org.hibernate.annotations.SQLRestriction;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@SQLDelete(sql = "UPDATE interest_protecting_report SET status = 'N' WHERE interest_protecting_id = ?")
 @SQLRestriction("status = 'Y'")
 public class InterestProtectingReport extends BaseEntity {
 

--- a/src/main/java/com/kuit/findyou/domain/report/model/InterestReport.java
+++ b/src/main/java/com/kuit/findyou/domain/report/model/InterestReport.java
@@ -15,7 +15,6 @@ import org.hibernate.annotations.SQLRestriction;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@SQLDelete(sql = "UPDATE interest_report SET status = 'N' WHERE interest_report_id = ?")
 @SQLRestriction("status = 'Y'")
 public class InterestReport extends BaseEntity {
 

--- a/src/main/java/com/kuit/findyou/domain/report/model/InterestReport.java
+++ b/src/main/java/com/kuit/findyou/domain/report/model/InterestReport.java
@@ -35,13 +35,19 @@ public class InterestReport extends BaseEntity {
     public static InterestReport createInterestReport(User user, Report report) {
         InterestReport interestReport = new InterestReport();
         interestReport.setUser(user);
-        interestReport.report = report;
+        interestReport.setReport(report); // 연관 관계 편의 메서드 적용
         return interestReport;
     }
 
-    // 연관 관계 편의 메서드
+    // User 에 대한 연관 관계 편의 메서드
     private void setUser(User user) {
         this.user = user;
         user.addInterestReport(this);
+    }
+
+    // Report 에 대한 연관 관계 편의 메서드
+    private void setReport(Report report) {
+        this.report = report;
+        report.addInterestReport(this);
     }
 }

--- a/src/main/java/com/kuit/findyou/domain/report/model/ProtectingReport.java
+++ b/src/main/java/com/kuit/findyou/domain/report/model/ProtectingReport.java
@@ -7,6 +7,8 @@ import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -82,6 +84,28 @@ public class ProtectingReport extends BaseEntity {
 
     @Column(name = "authority_phone_number", length = 14, nullable = false)
     private String authorityPhoneNumber;
+
+    // 최근 본 보호글 삭제를 위한 양방향 연관관계 설정
+    // orphanRemoval = true 만 설정
+    @OneToMany(mappedBy = "protectingReport", orphanRemoval = true)
+    @Builder.Default
+    private List<ViewedProtectingReport> viewedProtectingReports = new ArrayList<>();
+
+    // 관심 보호글 삭제를 위한 양방향 연관관계 설정
+    // orphanRemoval = true 만 설정
+    @OneToMany(mappedBy = "protectingReport", orphanRemoval = true)
+    @Builder.Default
+    private List<InterestProtectingReport> interestProtectingReports = new ArrayList<>();
+
+
+    public void addViewedProtectingReport(ViewedProtectingReport viewedProtectingReport) {
+        viewedProtectingReports.add(viewedProtectingReport);
+    }
+
+    public void addInterestProtectingReport(InterestProtectingReport interestProtectingReport) {
+        interestProtectingReports.add(interestProtectingReport);
+    }
+
 
     public String getNoticeDuration() {
         return noticeStartDate + " ~ " + noticeEndDate;

--- a/src/main/java/com/kuit/findyou/domain/report/model/Report.java
+++ b/src/main/java/com/kuit/findyou/domain/report/model/Report.java
@@ -49,8 +49,8 @@ public class Report extends BaseEntity {
     @JoinColumn(name = "report_animal_id", nullable = false)
     private ReportAnimal reportAnimal;
 
-    // 신고글 이미지에 대해 CascadeType.ALL 및 orphanRemoval = true 적용
-    @OneToMany(mappedBy = "report", cascade = CascadeType.ALL, orphanRemoval = true)
+    // 신고글 이미지에 대해 orphanRemoval = true 만 적용
+    @OneToMany(mappedBy = "report", orphanRemoval = true)
     private List<Image> images = new ArrayList<>();
 
     // 최근 본 신고글 삭제를 위한 양방향 연관관계 설정

--- a/src/main/java/com/kuit/findyou/domain/report/model/Report.java
+++ b/src/main/java/com/kuit/findyou/domain/report/model/Report.java
@@ -43,15 +43,25 @@ public class Report extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @OneToOne(fetch = FetchType.LAZY)
+
+    // 신고 동물에 대해 CascadeType.ALL 및 orphanRemoval = true 적용
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "report_animal_id", nullable = false)
     private ReportAnimal reportAnimal;
 
-
+    // 신고글 이미지에 대해 CascadeType.ALL 및 orphanRemoval = true 적용
     @OneToMany(mappedBy = "report", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Image> images = new ArrayList<>();
 
+    // 최근 본 신고글 삭제를 위한 양방향 연관관계 설정
+    // orphanRemoval = true 만 설정
+    @OneToMany(mappedBy = "report", orphanRemoval = true)
+    private List<ViewedReport> viewedReports = new ArrayList<>();
 
+    // 관심 신고글 삭제를 위한 양방향 연관관계 설정
+    // orphanRemoval = true 만 설정
+    @OneToMany(mappedBy = "report", orphanRemoval = true)
+    private List<InterestReport> interestReports = new ArrayList<>();
 
     //==생성 메서드==// -> 생성자 말고 생성 메서드를 별도로 만든 형태
     public static Report createReport(String tag, String foundLocation, LocalDate eventDate, String additionalDescription, User user, ReportAnimal reportAnimal, List<Image> images) {
@@ -91,9 +101,19 @@ public class Report extends BaseEntity {
             image.setReport(null);
         }
     }
+
     // 이미지 리스트 반환 메서드
     public List<Image> getImages() {
         return Collections.unmodifiableList(images);
+    }
+
+
+    public void addViewedReport(ViewedReport viewedReport) {
+        viewedReports.add(viewedReport);
+    }
+
+    public void addInterestReport(InterestReport interestReport) {
+        interestReports.add(interestReport);
     }
 
 }

--- a/src/main/java/com/kuit/findyou/domain/report/model/ReportAnimal.java
+++ b/src/main/java/com/kuit/findyou/domain/report/model/ReportAnimal.java
@@ -34,7 +34,8 @@ public class ReportAnimal extends BaseEntity {
     private Breed breed;
 
     // 신고 동물의 특징을 알아오기 위한 양방향 연관관계 설정
-    @OneToMany(mappedBy = "reportAnimal")
+    // 신고 동물 특징에 대해 CascadeType.ALL 과 orphanRemoval = true 설정
+    @OneToMany(mappedBy = "reportAnimal", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<ReportedAnimalFeature> reportedAnimalFeatures = new ArrayList<>();
 

--- a/src/main/java/com/kuit/findyou/domain/report/model/ViewedProtectingReport.java
+++ b/src/main/java/com/kuit/findyou/domain/report/model/ViewedProtectingReport.java
@@ -35,13 +35,19 @@ public class ViewedProtectingReport extends BaseEntity {
     public static ViewedProtectingReport createViewedProtectingReport(User user, ProtectingReport protectingReport) {
         ViewedProtectingReport viewedProtectingReport = new ViewedProtectingReport();
         viewedProtectingReport.setUser(user);
-        viewedProtectingReport.protectingReport = protectingReport;
+        viewedProtectingReport.setProtectingReport(protectingReport); // 연관 관계 편의 메서드 적용
         return viewedProtectingReport;
     }
 
-    // 연관 관계 편의 메서드
+    // User 에 대한 연관 관계 편의 메서드
     private void setUser(User user) {
         this.user = user;
         user.addViewedProtectingReport(this);
+    }
+
+    // ProtectingReport 에 대한 연관 관게 편의 메서드
+    private void setProtectingReport(ProtectingReport protectingReport) {
+        this.protectingReport = protectingReport;
+        protectingReport.addViewedProtectingReport(this);
     }
 }

--- a/src/main/java/com/kuit/findyou/domain/report/model/ViewedProtectingReport.java
+++ b/src/main/java/com/kuit/findyou/domain/report/model/ViewedProtectingReport.java
@@ -15,7 +15,6 @@ import org.hibernate.annotations.SQLRestriction;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@SQLDelete(sql = "UPDATE viewed_protecting_report SET status = 'N' WHERE viewed_protecting_report_id = ?")
 @SQLRestriction("status = 'Y'")
 public class ViewedProtectingReport extends BaseEntity {
 

--- a/src/main/java/com/kuit/findyou/domain/report/model/ViewedReport.java
+++ b/src/main/java/com/kuit/findyou/domain/report/model/ViewedReport.java
@@ -35,13 +35,19 @@ public class ViewedReport extends BaseEntity {
     public static ViewedReport createViewedReport(User user, Report report) {
         ViewedReport viewedReport = new ViewedReport();
         viewedReport.setUser(user);
-        viewedReport.report = report;
+        viewedReport.setReport(report);  // 연관 관계 편의 메서드 적용
         return viewedReport;
     }
 
-    // 연관 관계 편의 메서드
+    // User 에 대한 연관 관계 편의 메서드
     private void setUser(User user) {
         this.user = user;
         user.addViewedReport(this);
+    }
+
+    // Report 에 대한 연관 관계 편의 메서드
+    private void setReport(Report report) {
+        this.report = report;
+        report.addViewedReport(this);
     }
 }

--- a/src/main/java/com/kuit/findyou/domain/report/model/ViewedReport.java
+++ b/src/main/java/com/kuit/findyou/domain/report/model/ViewedReport.java
@@ -15,7 +15,6 @@ import org.hibernate.annotations.SQLRestriction;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@SQLDelete(sql = "UPDATE viewed_report SET status = 'N' WHERE viewed_report_id = ?")
 @SQLRestriction("status = 'Y'")
 public class ViewedReport extends BaseEntity {
 

--- a/src/test/java/com/kuit/findyou/domain/home/service/HomeServiceTest.java
+++ b/src/test/java/com/kuit/findyou/domain/home/service/HomeServiceTest.java
@@ -12,6 +12,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -98,12 +101,14 @@ public class HomeServiceTest {
                     .furColor("흰색, 검은색" + i)
                     .breed(breed)
                     .build();
-            reportAnimalRepository.save(reportAnimal);
 
             ReportedAnimalFeature reportedAnimalFeature = ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature);
-            reportedAnimalFeatureRepository.save(reportedAnimalFeature);
 
-            Report report = Report.createReport("목격 신고", "내집앞" + i, LocalDate.now(), "예쁘게 생김", user, reportAnimal);
+            List<Image> images = new ArrayList<>();
+            images.add(Image.createImage("C:/images/cloud/1.jpg", UUID.randomUUID().toString()));
+            images.add(Image.createImage("C:/images/cloud/2.jpg", UUID.randomUUID().toString()));
+
+            Report report = Report.createReport("목격 신고", "내집앞" + i, LocalDate.now(), "예쁘게 생김", user, reportAnimal, images);
             lastSavedReport = reportRepository.save(report);
         }
 

--- a/src/test/java/com/kuit/findyou/domain/home/service/HomeServiceTest.java
+++ b/src/test/java/com/kuit/findyou/domain/home/service/HomeServiceTest.java
@@ -37,13 +37,10 @@ public class HomeServiceTest {
     private AnimalFeatureRepository animalFeatureRepository;
 
     @Autowired
-    private ReportAnimalRepository reportAnimalRepository;
-
-    @Autowired
-    private ReportedAnimalFeatureRepository reportedAnimalFeatureRepository;
-
-    @Autowired
     private ReportRepository reportRepository;
+
+    @Autowired
+    private ImageRepository imageRepository;
 
     @Test
     void testGetHomeData(){
@@ -107,6 +104,8 @@ public class HomeServiceTest {
             List<Image> images = new ArrayList<>();
             images.add(Image.createImage("C:/images/cloud/1.jpg", UUID.randomUUID().toString()));
             images.add(Image.createImage("C:/images/cloud/2.jpg", UUID.randomUUID().toString()));
+
+            images.forEach(imageRepository::save);
 
             Report report = Report.createReport("목격 신고", "내집앞" + i, LocalDate.now(), "예쁘게 생김", user, reportAnimal, images);
             lastSavedReport = reportRepository.save(report);

--- a/src/test/java/com/kuit/findyou/domain/report/repository/InterestProtectingReportTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/repository/InterestProtectingReportTest.java
@@ -6,9 +6,15 @@ import com.kuit.findyou.domain.report.model.InterestProtectingReport;
 import com.kuit.findyou.domain.report.model.Neutering;
 import com.kuit.findyou.domain.report.model.ProtectingReport;
 import com.kuit.findyou.domain.report.model.Sex;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
@@ -20,6 +26,47 @@ class InterestProtectingReportTest {
     @Autowired private InterestProtectingReportRepository interestProtectingReportRepository;
     @Autowired private UserRepository userRepository;
     @Autowired private ProtectingReportRepository protectingReportRepository;
+
+
+    @BeforeEach
+    void setUp() {
+        User user = User.builder()
+                .name("김상균")
+                .email("ksg001227@naver.com")
+                .password("skcjswo00")
+                .build();
+
+        userRepository.save(user);
+
+        ProtectingReport protectingReport = ProtectingReport.builder()
+                .happenDate(LocalDate.now())
+                .imageUrl("image.jpg")
+                .species("개")
+                .noticeNumber("12345123")
+                .noticeStartDate(LocalDate.now())
+                .noticeEndDate(LocalDate.now())
+                .breed("시츄")
+                .furColor("갈색")
+                .weight(3.5F)
+                .age((short)2024)
+                .sex(Sex.M)
+                .neutering(Neutering.N)
+                .foundLocation("우리집 앞")
+                .significant("눈이 아파보임")
+                .careName("행운사")
+                .careAddr("용산구")
+                .careTel("02-1234-1234")
+                .authority("관할서")
+                .authorityPhoneNumber("02-111-4312")
+                .build();
+
+        protectingReportRepository.save(protectingReport);
+
+        InterestProtectingReport interestProtectingReport = InterestProtectingReport.createInterestProtectingReport(user, protectingReport);
+        interestProtectingReportRepository.save(interestProtectingReport);
+
+    }
+
 
     @Test
     void save() {
@@ -64,5 +111,34 @@ class InterestProtectingReportTest {
         }
 
     }
+
+    @Test
+    void delete() {
+        InterestProtectingReport interestProtectingReport = interestProtectingReportRepository.findById(1L).get();
+
+        interestProtectingReportRepository.delete(interestProtectingReport);
+    }
+
+    @Test
+    @DisplayName("유저 삭제시 관심 보호글 삭제 여부 확인")
+    void UserCascadeDelete() {
+        User user = userRepository.findById(1L).get();
+
+        userRepository.delete(user);
+
+        Assertions.assertThat(interestProtectingReportRepository.findById(1L)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("보호글 삭제시 관심 보호글 삭제 여부 확인")
+    void ProtectingReportCascadeDelete() {
+        ProtectingReport protectingReport = protectingReportRepository.findById(1L).get();
+
+        protectingReportRepository.delete(protectingReport);
+
+        Assertions.assertThat(interestProtectingReportRepository.findById(1L)).isEmpty();
+    }
+
+
 
 }

--- a/src/test/java/com/kuit/findyou/domain/report/repository/InterestReportRepositoryTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/repository/InterestReportRepositoryTest.java
@@ -3,14 +3,19 @@ package com.kuit.findyou.domain.report.repository;
 import com.kuit.findyou.domain.auth.model.User;
 import com.kuit.findyou.domain.auth.repository.UserRepository;
 import com.kuit.findyou.domain.report.model.*;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @SpringBootTest
@@ -22,6 +27,46 @@ class InterestReportRepositoryTest {
     @Autowired private ReportRepository reportRepository;
     @Autowired private BreedRepository breedRepository;
     @Autowired private ReportAnimalRepository reportAnimalRepository;
+
+    @BeforeEach
+    void setUp() {
+        User user = User.builder()
+                .name("김상균")
+                .email("ksg001227@naver.com")
+                .password("skcjswo00")
+                .build();
+
+        userRepository.save(user);
+
+
+        Breed breed = Breed.builder()
+                .name("치와와")
+                .species("개")
+                .build();
+
+        breedRepository.save(breed);
+
+
+        ReportAnimal reportAnimal = ReportAnimal.builder()
+                .furColor("흰색, 검은색")
+                .breed(breed)
+                .build();
+
+        reportAnimalRepository.save(reportAnimal);
+
+        Image image1 = Image.createImage("C:/images/cloud/1.jpg", UUID.randomUUID().toString());
+        Image image2 = Image.createImage("C:/images/cloud/2.jpg", UUID.randomUUID().toString());
+        List<Image> images = new ArrayList<>();
+        images.add(image1);
+        images.add(image2);
+
+
+        Report report = Report.createReport("목격 신고", "내집앞", LocalDate.now(), "예쁘게 생김", user, reportAnimal, images);
+        reportRepository.save(report);
+
+        InterestReport viewedReport = InterestReport.createInterestReport(user, report);
+        interestReportRepository.save(viewedReport);
+    }
 
     @Test
     void save() {
@@ -73,5 +118,34 @@ class InterestReportRepositoryTest {
             System.out.println(interestReport.getReport().getEventDate());
         }
     }
+
+    @Test
+    void delete() {
+        InterestReport interestReport = interestReportRepository.findById(1L).get();
+
+        interestReportRepository.delete(interestReport);
+    }
+
+    @Test
+    @DisplayName("유저 삭제시 관심 신고글 삭제 여부 확인")
+    void UserCascadeDelete() {
+        User user = userRepository.findById(1L).get();
+
+        userRepository.delete(user);
+
+        Assertions.assertThat(interestReportRepository.findById(1L)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("신고글 삭제 시 관심 신고글 삭제 여부 확인")
+    void ReportCascadeDelete() {
+        Report report = reportRepository.findById(1L).get();
+
+        reportRepository.delete(report);
+
+        Assertions.assertThat(interestReportRepository.findById(1L)).isEmpty();
+    }
+
+
 
 }

--- a/src/test/java/com/kuit/findyou/domain/report/repository/InterestReportRepositoryTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/repository/InterestReportRepositoryTest.java
@@ -63,8 +63,13 @@ class InterestReportRepositoryTest {
         interestReportRepository.save(viewedReport);
 
         User findUser = userRepository.findById(user.getId()).get();
+        Report findReport = reportRepository.findById(viewedReport.getId()).get();
 
         for(InterestReport interestReport : findUser.getInterestReports()) {
+            System.out.println(interestReport.getReport().getEventDate());
+        }
+
+        for(InterestReport interestReport : findReport.getInterestReports()) {
             System.out.println(interestReport.getReport().getEventDate());
         }
     }

--- a/src/test/java/com/kuit/findyou/domain/report/repository/InterestReportRepositoryTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/repository/InterestReportRepositoryTest.java
@@ -27,6 +27,7 @@ class InterestReportRepositoryTest {
     @Autowired private ReportRepository reportRepository;
     @Autowired private BreedRepository breedRepository;
     @Autowired private ReportAnimalRepository reportAnimalRepository;
+    @Autowired private ImageRepository imageRepository;
 
     @BeforeEach
     void setUp() {
@@ -60,6 +61,7 @@ class InterestReportRepositoryTest {
         images.add(image1);
         images.add(image2);
 
+        images.forEach(imageRepository::save);
 
         Report report = Report.createReport("목격 신고", "내집앞", LocalDate.now(), "예쁘게 생김", user, reportAnimal, images);
         reportRepository.save(report);
@@ -99,6 +101,8 @@ class InterestReportRepositoryTest {
         List<Image> images = new ArrayList<>();
         images.add(image1);
         images.add(image2);
+
+        images.forEach(imageRepository::save);
 
 
         Report report = Report.createReport("목격 신고", "내집앞", LocalDate.now(), "예쁘게 생김", user, reportAnimal, images);

--- a/src/test/java/com/kuit/findyou/domain/report/repository/ReportRepositoryTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/repository/ReportRepositoryTest.java
@@ -23,10 +23,7 @@ class ReportRepositoryTest {
     private UserRepository userRepository;
 
     @Autowired private BreedRepository breedRepository;
-    @Autowired private ReportAnimalRepository reportAnimalRepository;
     @Autowired private AnimalFeatureRepository animalFeatureRepository;
-    @Autowired private ReportedAnimalFeatureRepository reportedAnimalFeatureRepository;
-    @Autowired private ImageRepository imageRepository;
 
 
     @Test
@@ -46,33 +43,18 @@ class ReportRepositoryTest {
 
         breedRepository.save(breed);
 
-        ReportAnimal reportAnimal = ReportAnimal.builder()
-                .furColor("흰색, 검은색")
-                .breed(breed)
-                .build();
-        reportAnimalRepository.save(reportAnimal);
-
-
-        ReportAnimal reportAnimal2 = ReportAnimal.builder()
-                .furColor("갈색")
-                .breed(breed)
-                .build();
-        reportAnimalRepository.save(reportAnimal2);
-
         AnimalFeature animalFeature = AnimalFeature.builder().featureValue("순해요").build();
         AnimalFeature animalFeature2 = AnimalFeature.builder().featureValue("물어요").build();
         animalFeatureRepository.save(animalFeature);
         animalFeatureRepository.save(animalFeature2);
 
-        ReportedAnimalFeature reportedAnimalFeature = ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature);
-        ReportedAnimalFeature reportedAnimalFeature2 = ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature2);
-        ReportedAnimalFeature reportedAnimalFeature3 = ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal2, animalFeature);
-        ReportedAnimalFeature reportedAnimalFeature4 = ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal2, animalFeature2);
+        ReportAnimal reportAnimal = ReportAnimal.builder()
+                .furColor("흰색, 검은색")
+                .breed(breed)
+                .build();
 
-        reportedAnimalFeatureRepository.save(reportedAnimalFeature);
-        reportedAnimalFeatureRepository.save(reportedAnimalFeature2);
-        reportedAnimalFeatureRepository.save(reportedAnimalFeature3);
-        reportedAnimalFeatureRepository.save(reportedAnimalFeature4);
+        ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature);
+        ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature2);
 
         // 이미지 객체 생성
         List<Image> images = new ArrayList<>();
@@ -81,23 +63,22 @@ class ReportRepositoryTest {
 
 
         Report report = Report.createReport("목격 신고", "내집앞", LocalDate.now(), "예쁘게 생김", user, reportAnimal, images);
-        Report report2 = Report.createReport("실종 신고", "여자친구 집 앞", LocalDate.now(), "못생김", user, reportAnimal2, images);
         reportRepository.save(report);
-        reportRepository.save(report2);
 
-        images.forEach(imageRepository::save);
+        // 신고 동물, 신고 동물 특징, 신고글 이미지 정보를 명시적으로 save 해주지 않아도 연관 관계를 적절히 맺어주고 Report 만 save 하면 자동으로 DB에 insert 되는 것을 확인할 수 있음
 
+//        images.forEach(imageRepository::save);
 
-        Report findReport = reportRepository.findById(report.getId()).get();
-        ReportAnimal findAnimal = findReport.getReportAnimal();
-        for(ReportedAnimalFeature reportedAnimalFeature1 : findAnimal.getReportedAnimalFeatures()) {
-            System.out.println(reportedAnimalFeature1.getFeature().getFeatureValue());
-        }
-
-        User findUser = userRepository.findById(user.getId()).get();
-        for(Report report1 : findUser.getReports()) {
-            System.out.println(report1.getEventLocation());
-        }
+//        Report findReport = reportRepository.findById(report.getId()).get();
+//        ReportAnimal findAnimal = findReport.getReportAnimal();
+//        for(ReportedAnimalFeature reportedAnimalFeature1 : findAnimal.getReportedAnimalFeatures()) {
+//            System.out.println(reportedAnimalFeature1.getFeature().getFeatureValue());
+//        }
+//
+//        User findUser = userRepository.findById(user.getId()).get();
+//        for(Report report1 : findUser.getReports()) {
+//            System.out.println(report1.getFoundLocation());
+//        }
 
     }
 

--- a/src/test/java/com/kuit/findyou/domain/report/repository/ReportRepositoryTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/repository/ReportRepositoryTest.java
@@ -68,7 +68,8 @@ class ReportRepositoryTest {
         images.add(Image.createImage("C:/images/cloud/1.jpg", UUID.randomUUID().toString()));
         images.add(Image.createImage("C:/images/cloud/2.jpg", UUID.randomUUID().toString()));
 
-
+        images.forEach(imageRepository::save);
+        
         Report report = Report.createReport("목격 신고", "내집앞", LocalDate.now(), "예쁘게 생김", user, reportAnimal, images);
         reportRepository.save(report);
     }

--- a/src/test/java/com/kuit/findyou/domain/report/repository/ReportedAnimalFeatureRepositoryTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/repository/ReportedAnimalFeatureRepositoryTest.java
@@ -4,9 +4,13 @@ import com.kuit.findyou.domain.report.model.AnimalFeature;
 import com.kuit.findyou.domain.report.model.Breed;
 import com.kuit.findyou.domain.report.model.ReportAnimal;
 import com.kuit.findyou.domain.report.model.ReportedAnimalFeature;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
@@ -19,6 +23,35 @@ class ReportedAnimalFeatureRepositoryTest {
     private BreedRepository breedRepository;
     @Autowired
     private ReportAnimalRepository reportAnimalRepository;
+    @Autowired
+    private ReportedAnimalFeatureRepository reportedAnimalFeatureRepository;
+
+    @BeforeEach
+    void setUp() {
+        Breed breed = Breed.builder()
+                .name("시츄")
+                .species("개")
+                .build();
+        breedRepository.save(breed);
+
+        Breed findBreed = breedRepository.findById(breed.getId()).get();
+
+        AnimalFeature animalFeature = AnimalFeature.builder().featureValue("순해요").build();
+        AnimalFeature animalFeature2 = AnimalFeature.builder().featureValue("물어요").build();
+        animalFeatureRepository.save(animalFeature);
+        animalFeatureRepository.save(animalFeature2);
+
+        ReportAnimal reportAnimal = ReportAnimal.builder()
+                .furColor("흰색, 검은색")
+                .breed(findBreed)
+                .build();
+
+        ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature);
+        ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature2);
+
+        reportAnimalRepository.save(reportAnimal);
+    }
+
 
     @Test
     void save() {
@@ -53,6 +86,16 @@ class ReportedAnimalFeatureRepositoryTest {
 //        }
 
 
+    }
+
+    @Test
+    @DisplayName("신고 동물 삭제시 신고 동물 특징 삭제 여부 확인")
+    void delete() {
+        ReportAnimal reportAnimal = reportAnimalRepository.findById(1L).get();
+
+        reportAnimalRepository.delete(reportAnimal);
+
+        Assertions.assertThat(reportedAnimalFeatureRepository.findAll()).isEmpty();
     }
 
 

--- a/src/test/java/com/kuit/findyou/domain/report/repository/ReportedAnimalFeatureRepositoryTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/repository/ReportedAnimalFeatureRepositoryTest.java
@@ -14,8 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 class ReportedAnimalFeatureRepositoryTest {
 
     @Autowired
-    private ReportedAnimalFeatureRepository reportedAnimalFeatureRepository;
-    @Autowired
     private AnimalFeatureRepository animalFeatureRepository;
     @Autowired
     private BreedRepository breedRepository;
@@ -32,27 +30,27 @@ class ReportedAnimalFeatureRepositoryTest {
 
         Breed findBreed = breedRepository.findById(breed.getId()).get();
 
-        ReportAnimal reportAnimal = ReportAnimal.builder()
-                .furColor("흰색, 검은색")
-                .breed(findBreed)
-                .build();
-        reportAnimalRepository.save(reportAnimal);
-
         AnimalFeature animalFeature = AnimalFeature.builder().featureValue("순해요").build();
         AnimalFeature animalFeature2 = AnimalFeature.builder().featureValue("물어요").build();
         animalFeatureRepository.save(animalFeature);
         animalFeatureRepository.save(animalFeature2);
 
-        ReportedAnimalFeature reportedAnimalFeature = ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature);
-        ReportedAnimalFeature reportedAnimalFeature2 = ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature2);
+        ReportAnimal reportAnimal = ReportAnimal.builder()
+                .furColor("흰색, 검은색")
+                .breed(findBreed)
+                .build();
 
-        reportedAnimalFeatureRepository.save(reportedAnimalFeature);
-        reportedAnimalFeatureRepository.save(reportedAnimalFeature2);
+        ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature);
+        ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature2);
 
-        ReportAnimal findAnimal = reportAnimalRepository.findById(reportAnimal.getId()).get();
-        for(ReportedAnimalFeature features : findAnimal.getReportedAnimalFeatures()) {
-            System.out.println(features.getFeature().getFeatureValue());
-        }
+        reportAnimalRepository.save(reportAnimal);
+
+        // ReportedAnimalFeature 를 명시적으로 save 해주지 않아도 reportAnimal을 save하는 순간 DB에 자동으로 데이터가 삽입됨
+
+//        ReportAnimal findAnimal = reportAnimalRepository.findById(reportAnimal.getId()).get();
+//        for(ReportedAnimalFeature features : findAnimal.getReportedAnimalFeatures()) {
+//            System.out.println(features.getFeature().getFeatureValue());
+//        }
 
 
     }

--- a/src/test/java/com/kuit/findyou/domain/report/repository/ViewedProtectingReportRepositoryTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/repository/ViewedProtectingReportRepositoryTest.java
@@ -6,21 +6,64 @@ import com.kuit.findyou.domain.report.model.Neutering;
 import com.kuit.findyou.domain.report.model.ProtectingReport;
 import com.kuit.findyou.domain.report.model.Sex;
 import com.kuit.findyou.domain.report.model.ViewedProtectingReport;
-import org.junit.jupiter.api.Assertions;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.Optional;
 
 @SpringBootTest
-//@Transactional
+@Transactional
 class ViewedProtectingReportRepositoryTest {
 
     @Autowired private ViewedProtectingReportRepository viewedProtectingReportRepository;
     @Autowired private UserRepository userRepository;
     @Autowired private ProtectingReportRepository protectingReportRepository;
+
+    @BeforeEach
+    void setUp() {
+        User user = User.builder()
+                .name("김상균")
+                .email("ksg001227@naver.com")
+                .password("skcjswo00")
+                .build();
+
+        userRepository.save(user);
+
+        ProtectingReport protectingReport = ProtectingReport.builder()
+                .happenDate(LocalDate.now())
+                .imageUrl("image.jpg")
+                .species("개")
+                .noticeNumber("12345123")
+                .noticeStartDate(LocalDate.now())
+                .noticeEndDate(LocalDate.now())
+                .breed("시츄")
+                .furColor("갈색")
+                .weight(3.5F)
+                .age((short)2024)
+                .sex(Sex.M)
+                .neutering(Neutering.N)
+                .foundLocation("우리집 앞")
+                .significant("눈이 아파보임")
+                .careName("행운사")
+                .careAddr("용산구")
+                .careTel("02-1234-1234")
+                .authority("관할서")
+                .authorityPhoneNumber("02-111-4312")
+                .build();
+
+        protectingReportRepository.save(protectingReport);
+
+        ViewedProtectingReport viewedProtectingReport = ViewedProtectingReport.createViewedProtectingReport(user, protectingReport);
+        viewedProtectingReportRepository.save(viewedProtectingReport);
+    }
+
 
     @Test
     void save() {
@@ -58,6 +101,32 @@ class ViewedProtectingReportRepositoryTest {
 
         ViewedProtectingReport viewedProtectingReport = ViewedProtectingReport.createViewedProtectingReport(user, protectingReport);
         viewedProtectingReportRepository.save(viewedProtectingReport);
+    }
+
+    @Test
+    void delete() {
+        ViewedProtectingReport viewedProtectingReport = viewedProtectingReportRepository.findById(1L).get();
+        viewedProtectingReportRepository.delete(viewedProtectingReport);
+    }
+
+    @Test
+    @DisplayName("유저 삭제시 최근 본 보호글 삭제 여부 확인")
+    void UserCascadeDelete() {
+        User user = userRepository.findById(1L).get();
+
+        userRepository.delete(user);
+
+        Assertions.assertThat(viewedProtectingReportRepository.findById(1L)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("보호글 삭제시 최근 본 보호글 삭제 여부 확인")
+    void ProtectingReportCascadeDelete() {
+        ProtectingReport protectingReport = protectingReportRepository.findById(1L).get();
+
+        protectingReportRepository.delete(protectingReport);
+
+        Assertions.assertThat(viewedProtectingReportRepository.findById(1L)).isEmpty();
     }
 
     @Test
@@ -99,8 +168,8 @@ class ViewedProtectingReportRepositoryTest {
 
         Optional<ViewedProtectingReport> foundReport = viewedProtectingReportRepository.findByUserAndProtectingReport(user, protectingReport);
 
-        Assertions.assertTrue(foundReport.isPresent());
-        Assertions.assertEquals(viewedProtectingReport.getId(), foundReport.get().getId());
+        Assertions.assertThat(foundReport.isPresent()).isTrue();
+        Assertions.assertThat(viewedProtectingReport.getId()).isEqualTo(foundReport.get().getId());
     }
 
 }

--- a/src/test/java/com/kuit/findyou/domain/report/repository/ViewedReportRepositoryTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/repository/ViewedReportRepositoryTest.java
@@ -26,6 +26,7 @@ class ViewedReportRepositoryTest {
     @Autowired private UserRepository userRepository;
     @Autowired private ReportRepository reportRepository;
     @Autowired private BreedRepository breedRepository;
+    @Autowired private ImageRepository imageRepository;
 
     @BeforeEach
     void setUp() {
@@ -54,6 +55,8 @@ class ViewedReportRepositoryTest {
         List<Image> images = new ArrayList<>();
         images.add(Image.createImage("C:/images/cloud/1.jpg", UUID.randomUUID().toString()));
         images.add(Image.createImage("C:/images/cloud/2.jpg", UUID.randomUUID().toString()));
+
+        images.forEach(imageRepository::save);
 
         Report report = Report.createReport("목격 신고", "내집앞", LocalDate.now(), "예쁘게 생김", user, reportAnimal, images);
         reportRepository.save(report);
@@ -90,6 +93,8 @@ class ViewedReportRepositoryTest {
         List<Image> images = new ArrayList<>();
         images.add(Image.createImage("C:/images/cloud/1.jpg", UUID.randomUUID().toString()));
         images.add(Image.createImage("C:/images/cloud/2.jpg", UUID.randomUUID().toString()));
+
+        images.forEach(imageRepository::save);
 
         Report report = Report.createReport("목격 신고", "내집앞", LocalDate.now(), "예쁘게 생김", user, reportAnimal, images);
         reportRepository.save(report);

--- a/src/test/java/com/kuit/findyou/domain/report/repository/ViewedReportRepositoryTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/repository/ViewedReportRepositoryTest.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 @SpringBootTest
-@Transactional
+//@Transactional
 class ViewedReportRepositoryTest {
 
     @Autowired private ViewedReportRepository viewedReportRepository;
@@ -47,8 +47,6 @@ class ViewedReportRepositoryTest {
                 .furColor("흰색, 검은색")
                 .breed(breed)
                 .build();
-
-        reportAnimalRepository.save(reportAnimal);
 
         // 이미지 객체 생성
         List<Image> images = new ArrayList<>();
@@ -84,8 +82,6 @@ class ViewedReportRepositoryTest {
                 .furColor("흰색, 검은색")
                 .breed(breed)
                 .build();
-
-        reportAnimalRepository.save(reportAnimal);
 
         // 이미지 객체 생성
         List<Image> images = new ArrayList<>();

--- a/src/test/java/com/kuit/findyou/domain/report/repository/ViewedReportRepositoryTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/repository/ViewedReportRepositoryTest.java
@@ -3,10 +3,13 @@ package com.kuit.findyou.domain.report.repository;
 import com.kuit.findyou.domain.auth.model.User;
 import com.kuit.findyou.domain.auth.repository.UserRepository;
 import com.kuit.findyou.domain.report.model.*;
-import org.junit.jupiter.api.Assertions;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
@@ -16,14 +19,49 @@ import java.util.Optional;
 import java.util.UUID;
 
 @SpringBootTest
-//@Transactional
+@Transactional
 class ViewedReportRepositoryTest {
 
     @Autowired private ViewedReportRepository viewedReportRepository;
     @Autowired private UserRepository userRepository;
     @Autowired private ReportRepository reportRepository;
     @Autowired private BreedRepository breedRepository;
-    @Autowired private ReportAnimalRepository reportAnimalRepository;
+
+    @BeforeEach
+    void setUp() {
+        User user = User.builder()
+                .name("김상균")
+                .email("ksg001227@naver.com")
+                .password("skcjswo00")
+                .build();
+
+        userRepository.save(user);
+
+        Breed breed = Breed.builder()
+                .name("치와와")
+                .species("개")
+                .build();
+
+        breedRepository.save(breed);
+
+
+        ReportAnimal reportAnimal = ReportAnimal.builder()
+                .furColor("흰색, 검은색")
+                .breed(breed)
+                .build();
+
+        // 이미지 객체 생성
+        List<Image> images = new ArrayList<>();
+        images.add(Image.createImage("C:/images/cloud/1.jpg", UUID.randomUUID().toString()));
+        images.add(Image.createImage("C:/images/cloud/2.jpg", UUID.randomUUID().toString()));
+
+        Report report = Report.createReport("목격 신고", "내집앞", LocalDate.now(), "예쁘게 생김", user, reportAnimal, images);
+        reportRepository.save(report);
+
+        ViewedReport viewedReport = ViewedReport.createViewedReport(user, report);
+        viewedReportRepository.save(viewedReport);
+    }
+
 
     @Test
     void save() {
@@ -58,6 +96,32 @@ class ViewedReportRepositoryTest {
 
         ViewedReport viewedReport = ViewedReport.createViewedReport(user, report);
         viewedReportRepository.save(viewedReport);
+    }
+
+    @Test
+    void delete() {
+        ViewedReport viewedReport = viewedReportRepository.findById(1L).get();
+        viewedReportRepository.delete(viewedReport);
+    }
+
+    @Test
+    @DisplayName("유저 삭제시 최근 본 신고글 삭제 여부 확인")
+    void UserCascadeDelete() {
+        User user = userRepository.findById(1L).get();
+
+        userRepository.delete(user);
+
+        Assertions.assertThat(viewedReportRepository.findById(1L)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("신고글 삭제시 최근 본 신고글 삭제 여부 확인")
+    void ProtectingReportCascadeDelete() {
+        Report report = reportRepository.findById(1L).get();
+
+        reportRepository.delete(report);
+
+        Assertions.assertThat(viewedReportRepository.findById(1L)).isEmpty();
     }
 
     @Test
@@ -97,8 +161,8 @@ class ViewedReportRepositoryTest {
 
         Optional<ViewedReport> foundReport = viewedReportRepository.findByUserAndReport(user, report);
 
-        Assertions.assertTrue(foundReport.isPresent());
-        Assertions.assertEquals(viewedReport.getId(), foundReport.get().getId());
+        Assertions.assertThat(foundReport.isPresent()).isTrue();
+        Assertions.assertThat(viewedReport.getId()).isEqualTo(foundReport.get().getId());
 
 
     }

--- a/src/test/java/com/kuit/findyou/domain/report/service/AnimalRetrieveServiceTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/service/AnimalRetrieveServiceTest.java
@@ -107,7 +107,6 @@ class AnimalRetrieveServiceTest {
                     .furColor(String.valueOf(i))
                     .breed(breed)
                     .build();
-            reportAnimalRepository.save(reportAnimal);
             //=========================================
 
 
@@ -115,8 +114,6 @@ class AnimalRetrieveServiceTest {
             // 신고 동물에 특징 매핑
             ReportedAnimalFeature reportedAnimalFeature = ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature);
             ReportedAnimalFeature reportedAnimalFeature2 = ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature2);
-            reportedAnimalFeatureRepository.save(reportedAnimalFeature);
-            reportedAnimalFeatureRepository.save(reportedAnimalFeature2);
 
             //=========================================
             // 신고글 작성

--- a/src/test/java/com/kuit/findyou/domain/report/service/AnimalRetrieveServiceTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/service/AnimalRetrieveServiceTest.java
@@ -36,7 +36,10 @@ class AnimalRetrieveServiceTest {
     @Autowired AnimalFeatureRepository animalFeatureRepository;
     @Autowired InterestReportRepository interestReportRepository;
     @Autowired BreedRepository breedRepository;
+    @Autowired ImageRepository imageRepository;
+
     @Autowired ReportAnimalRetrieveService reportAnimalRetrieveService;
+
 
     @BeforeEach
     void setUp() {
@@ -112,8 +115,8 @@ class AnimalRetrieveServiceTest {
 
             //=========================================
             // 신고 동물에 특징 매핑
-            ReportedAnimalFeature reportedAnimalFeature = ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature);
-            ReportedAnimalFeature reportedAnimalFeature2 = ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature2);
+            ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature);
+            ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature2);
 
             //=========================================
             // 신고글 작성
@@ -127,6 +130,8 @@ class AnimalRetrieveServiceTest {
             List<Image> images = new ArrayList<>();
             images.add(Image.createImage("C:/images/cloud/1.jpg", UUID.randomUUID().toString()));
             images.add(Image.createImage("C:/images/cloud/2.jpg", UUID.randomUUID().toString()));
+
+            images.forEach(imageRepository::save);
             //=========================================
 
             Report report = Report.createReport(tag, String.valueOf(i), LocalDate.now(), String.valueOf(i), user, reportAnimal, images);

--- a/src/test/java/com/kuit/findyou/domain/report/service/ReportAnimalInfoServiceTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/service/ReportAnimalInfoServiceTest.java
@@ -34,6 +34,7 @@ class ReportAnimalInfoServiceTest {
     @Autowired UserRepository userRepository;
     @Autowired InterestReportRepository interestReportRepository;
     @Autowired BreedRepository breedRepository;
+    @Autowired ImageRepository imageRepository;
 
     @PersistenceContext
     private EntityManager em;
@@ -87,6 +88,8 @@ class ReportAnimalInfoServiceTest {
         List<Image> images = new ArrayList<>();
         images.add(Image.createImage("C:/images/cloud/1.jpg", UUID.randomUUID().toString()));
         images.add(Image.createImage("C:/images/cloud/2.jpg", UUID.randomUUID().toString()));
+
+        images.forEach(imageRepository::save);
         //=========================================
 
         //=========================================

--- a/src/test/java/com/kuit/findyou/domain/report/service/ReportAnimalInfoServiceTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/service/ReportAnimalInfoServiceTest.java
@@ -67,7 +67,6 @@ class ReportAnimalInfoServiceTest {
                 .furColor("흰색, 검은색")
                 .breed(breed)
                 .build();
-        reportAnimalRepository.save(reportAnimal);
         //=========================================
 
         //=========================================
@@ -80,10 +79,8 @@ class ReportAnimalInfoServiceTest {
 
         //=========================================
         // 신고 동물에 특징 매핑
-        ReportedAnimalFeature reportedAnimalFeature = ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature);
-        ReportedAnimalFeature reportedAnimalFeature2 = ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature2);
-        reportedAnimalFeatureRepository.save(reportedAnimalFeature);
-        reportedAnimalFeatureRepository.save(reportedAnimalFeature2);
+        ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature);
+        ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature2);
 
         //=========================================
         // 이미지 객체 생성
@@ -107,7 +104,7 @@ class ReportAnimalInfoServiceTest {
 
     @Test
     void findReportInfoById() {
-        Long reportId = 21L;
+        Long reportId = 1L;
         Long userId = 1L;
 
         User findUser = userRepository.findById(userId).get();

--- a/src/test/java/com/kuit/findyou/domain/report/service/ReportAnimalRetrieveServiceTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/service/ReportAnimalRetrieveServiceTest.java
@@ -80,16 +80,13 @@ class ReportAnimalRetrieveServiceTest {
                     .furColor(String.valueOf(i))
                     .breed(breed)
                     .build();
-            reportAnimalRepository.save(reportAnimal);
             //=========================================
 
 
             //=========================================
             // 신고 동물에 특징 매핑
-            ReportedAnimalFeature reportedAnimalFeature = ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature);
-            ReportedAnimalFeature reportedAnimalFeature2 = ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature2);
-            reportedAnimalFeatureRepository.save(reportedAnimalFeature);
-            reportedAnimalFeatureRepository.save(reportedAnimalFeature2);
+            ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature);
+            ReportedAnimalFeature.createReportedAnimalFeature(reportAnimal, animalFeature2);
 
             //=========================================
             // 이미지 객체 생성

--- a/src/test/java/com/kuit/findyou/domain/report/service/ReportAnimalRetrieveServiceTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/service/ReportAnimalRetrieveServiceTest.java
@@ -41,6 +41,8 @@ class ReportAnimalRetrieveServiceTest {
     BreedRepository breedRepository;
     @Autowired
     ReportAnimalRetrieveService reportAnimalRetrieveService;
+    @Autowired
+    ImageRepository imageRepository;
 
     @BeforeEach
     void setUp() {
@@ -93,6 +95,8 @@ class ReportAnimalRetrieveServiceTest {
             List<Image> images = new ArrayList<>();
             images.add(Image.createImage("C:/images/cloud/1.jpg", UUID.randomUUID().toString()));
             images.add(Image.createImage("C:/images/cloud/2.jpg", UUID.randomUUID().toString()));
+
+            images.forEach(imageRepository::save);
             //=========================================
 
             //=========================================


### PR DESCRIPTION
## Related issue 🛠
- closed #24 

## Work Description 📝
- cascade 연관 관계 설정 완료
- Report와 ProtectingReport 쪽에 cascade를 통해 중간 테이블 엔티티들을 삭제해주기 위해 양방향 연관 관계 추가

- 신고글 - 신고 동물 -> CascadeType.ALL + orphanRemoval = true
- 신고 동물 - 신고 동물 특징 -> CascadeType.ALL + orphanRemoval = true
- 신고글 - 신고글 이미지 -> CascadeType.ALL + orphanRemoval = true
- 유저 - 신고글 -> orphanRemoval = true + orphanRemoval = true
- 관심 신고글, 관심 보호글, 최근 본 신고글, 최근 본 보호글 -> 모두 부모 엔티티와는 orphanRemoval = true 만 설정

- cascade 관련 save, delete 테스트 로직 작성

## Screenshot 📸

## Uncompleted Tasks 😅
- [ ] 조회 시 이미지 정보를 반환해야하나, Image 엔티티의 데이터를 어떤 식으로 조합해서 반환해야할지 모호해서 일단 미뤄둠

## To Reviewers 📢

기존 PR 올린 브랜치에서 설정을 뭘 잘못했는지 동작이 꼬여버려서 PR을 다시 올립니다 죄송합니다.. 

우선 익환이가 말했던 테스트는 전체 테스트가 아니라 개별적으로 테스트를 돌리면 문제 없이 돌아갑니다. 예외 형태가 NoSushElementException인 것을 보니 아마 @BeforeEach로 설정한 메서드가 모든 테스트에 대해 동작하면서 이상하게 동작되는 것 같아요.

그리고 Image와 Report간의 CascadeType.ALL 은 삭제했습니다
