### PR TITLE
[Feat] #31 관심 동물 등록 해제 기능 구현

### DIFF
--- a/src/main/java/com/kuit/findyou/domain/auth/model/User.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/model/User.java
@@ -110,18 +110,4 @@ public class User extends BaseEntity {
 
         return false;
     }
-
-    public void removeInterestReport(InterestReport interestReport) {
-        if(interestReport == null){
-            return;
-        }
-        this.interestReports.remove(interestReport);
-    }
-
-    public void removeInterestProtectingReport(InterestProtectingReport interestProtectingReport) {
-        if(interestProtectingReport == null){
-            return;
-        }
-        this.interestProtectingReports.remove(interestProtectingReport);
-    }
 }

--- a/src/main/java/com/kuit/findyou/domain/auth/model/User.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/model/User.java
@@ -110,4 +110,18 @@ public class User extends BaseEntity {
 
         return false;
     }
+
+    public void removeInterestReport(InterestReport interestReport) {
+        if(interestReport == null){
+            return;
+        }
+        this.interestReports.remove(interestReport);
+    }
+
+    public void removeInterestProtectingReport(InterestProtectingReport interestProtectingReport) {
+        if(interestProtectingReport == null){
+            return;
+        }
+        this.interestProtectingReports.remove(interestProtectingReport);
+    }
 }

--- a/src/main/java/com/kuit/findyou/domain/report/model/Report.java
+++ b/src/main/java/com/kuit/findyou/domain/report/model/Report.java
@@ -72,7 +72,7 @@ public class Report extends BaseEntity {
         report.additionalDescription = additionalDescription;
         report.setUser(user);
         report.reportAnimal = reportAnimal;
-        if(images != null || images.size() == 0) {
+        if(images != null && images.size() != 0) {
             images.forEach(report::addImage);
         }
         return report;

--- a/src/main/java/com/kuit/findyou/domain/report/model/Report.java
+++ b/src/main/java/com/kuit/findyou/domain/report/model/Report.java
@@ -72,7 +72,9 @@ public class Report extends BaseEntity {
         report.additionalDescription = additionalDescription;
         report.setUser(user);
         report.reportAnimal = reportAnimal;
-        images.forEach(report::addImage);
+        if(images != null || images.size() == 0) {
+            images.forEach(report::addImage);
+        }
         return report;
     }
 

--- a/src/main/java/com/kuit/findyou/domain/user/controller/UserController.java
+++ b/src/main/java/com/kuit/findyou/domain/user/controller/UserController.java
@@ -18,7 +18,6 @@ import static com.kuit.findyou.global.common.response.status.BaseExceptionRespon
 @RequestMapping("api/v1/users")
 public class UserController {
     private final UserService userService;
-
     @PostMapping("interest-animals")
     public BaseResponse<Long> postInterestAnimal(@RequestBody PostInterestAnimalRequest request){
         // 토큰 구현이 안된 상태라서 미리 저장된 사용자 활용
@@ -32,6 +31,22 @@ public class UserController {
         }
         Long id = userService.saveInterestReportAnimal(userId, request);
         log.info("[postInterestAnimal] id = {}", id);
+        return new BaseResponse<>(null);
+    }
+
+    @DeleteMapping("interest-animals/protecting-animals/{interest_protecting_animal_id}")
+    public BaseResponse<Object> deleteInterestProtectingAnimal(@PathVariable("interest_protecting_animal_id") Long interestProtectingReportId){
+        log.info("[deleteInterestProtectingAnimal] interestProtectingReportId = {}", interestProtectingReportId);
+        long userId = 2L;
+        userService.removeInterestProtectingAnimal(userId, interestProtectingReportId);
+        return new BaseResponse<>(null);
+    }
+
+    @DeleteMapping("interest-animals/report-animals/{report_animal_id}")
+    public BaseResponse<Object> deleteInterestReportAnimal(@PathVariable("report_animal_id") Long reportId){
+        log.info("[deleteInterestReportAnimal] id = {}", reportId);
+        Long userId = 1L;
+        userService.removeInterestReportAnimal(userId, reportId);
         return new BaseResponse<>(null);
     }
 

--- a/src/main/java/com/kuit/findyou/domain/user/controller/UserController.java
+++ b/src/main/java/com/kuit/findyou/domain/user/controller/UserController.java
@@ -27,17 +27,17 @@ public class UserController {
         if(isProtectingReport(request)) {
             Long id = userService.saveInterestProtectingAnimal(userId, request);
             log.info("[postInterestAnimal] id = {}", id);
-            return new BaseResponse<>(null);
+            return new BaseResponse<>(id);
         }
         Long id = userService.saveInterestReportAnimal(userId, request);
         log.info("[postInterestAnimal] id = {}", id);
-        return new BaseResponse<>(null);
+        return new BaseResponse<>(id);
     }
 
     @DeleteMapping("interest-animals/protecting-animals/{interest_protecting_animal_id}")
     public BaseResponse<Object> deleteInterestProtectingAnimal(@PathVariable("interest_protecting_animal_id") Long interestProtectingReportId){
         log.info("[deleteInterestProtectingAnimal] interestProtectingReportId = {}", interestProtectingReportId);
-        long userId = 2L;
+        long userId = 1L;
         userService.removeInterestProtectingAnimal(userId, interestProtectingReportId);
         return new BaseResponse<>(null);
     }

--- a/src/main/java/com/kuit/findyou/domain/user/exception/InterestAnimalNotFoundException.java
+++ b/src/main/java/com/kuit/findyou/domain/user/exception/InterestAnimalNotFoundException.java
@@ -1,0 +1,15 @@
+package com.kuit.findyou.domain.user.exception;
+
+import com.kuit.findyou.global.common.response.status.ResponseStatus;
+import lombok.Getter;
+
+@Getter
+public class InterestAnimalNotFoundException extends RuntimeException {
+
+    private final ResponseStatus exceptionStatus;
+
+    public InterestAnimalNotFoundException(ResponseStatus exceptionStatus) {
+        super(exceptionStatus.getMessage());
+        this.exceptionStatus = exceptionStatus;
+    }
+}

--- a/src/main/java/com/kuit/findyou/domain/user/exception_handler/UserControllerAdvice.java
+++ b/src/main/java/com/kuit/findyou/domain/user/exception_handler/UserControllerAdvice.java
@@ -1,6 +1,7 @@
 package com.kuit.findyou.domain.user.exception_handler;
 
 import com.kuit.findyou.domain.user.exception.AlreadySavedInterestException;
+import com.kuit.findyou.domain.user.exception.InterestAnimalNotFoundException;
 import com.kuit.findyou.global.common.response.BaseErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -19,5 +20,13 @@ public class UserControllerAdvice {
     public BaseErrorResponse handle_AlreadySavedInterestException(Exception e) {
         log.error("[handle_AlreadySavedInterestException]", e);
         return new BaseErrorResponse(ALREADY_SAVED_INTEREST_REPORT);
+    }
+
+    // 관심 동물이 존재하지 않는 경우
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(InterestAnimalNotFoundException.class)
+    public BaseErrorResponse handle_InterestAnimalNotFoundException(Exception e) {
+        log.error("[handle_InterestAnimalNotFoundException]", e);
+        return new BaseErrorResponse(INTEREST_ANIMAL_NOT_FOUND);
     }
 }

--- a/src/main/java/com/kuit/findyou/domain/user/service/UserService.java
+++ b/src/main/java/com/kuit/findyou/domain/user/service/UserService.java
@@ -16,10 +16,13 @@ import com.kuit.findyou.domain.user.exception.InterestAnimalNotFoundException;
 import com.kuit.findyou.global.common.exception.UnauthorizedUserException;
 import com.kuit.findyou.global.common.exception.ReportNotFoundException;
 import com.kuit.findyou.global.common.exception.UserNotFoundException;
+import jakarta.transaction.Transactional;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.*;
 
@@ -27,6 +30,7 @@ import static com.kuit.findyou.global.common.response.status.BaseExceptionRespon
 @Getter
 @RequiredArgsConstructor
 @Service
+@Transactional
 public class UserService {
     private final UserRepository userRepository;
     private final InterestProtectingReportRepository interestProtectingReportRepository;
@@ -82,6 +86,8 @@ public class UserService {
         if (interest.getUser().getId() != userId){
             throw new UnauthorizedUserException(UNATHORIZED_USER);
         }
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));
+        user.removeInterestProtectingReport(interest);
         interestProtectingReportRepository.delete(interest);
     }
 
@@ -90,6 +96,8 @@ public class UserService {
         if(interest.getUser().getId() != userId){
             throw new UnauthorizedUserException(UNATHORIZED_USER);
         }
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));
+        user.removeInterestReport(interest);
         interestReportRepository.delete(interest);
     }
 }

--- a/src/main/java/com/kuit/findyou/domain/user/service/UserService.java
+++ b/src/main/java/com/kuit/findyou/domain/user/service/UserService.java
@@ -2,7 +2,6 @@ package com.kuit.findyou.domain.user.service;
 
 import com.kuit.findyou.domain.auth.model.User;
 import com.kuit.findyou.domain.auth.repository.UserRepository;
-import com.kuit.findyou.domain.home.dto.ReportTag;
 import com.kuit.findyou.domain.report.model.InterestProtectingReport;
 import com.kuit.findyou.domain.report.model.InterestReport;
 import com.kuit.findyou.domain.report.model.ProtectingReport;
@@ -13,7 +12,8 @@ import com.kuit.findyou.domain.report.repository.ProtectingReportRepository;
 import com.kuit.findyou.domain.report.repository.ReportRepository;
 import com.kuit.findyou.domain.user.dto.PostInterestAnimalRequest;
 import com.kuit.findyou.domain.user.exception.AlreadySavedInterestException;
-import com.kuit.findyou.global.common.exception.BadRequestException;
+import com.kuit.findyou.domain.user.exception.InterestAnimalNotFoundException;
+import com.kuit.findyou.global.common.exception.UnauthorizedUserException;
 import com.kuit.findyou.global.common.exception.ReportNotFoundException;
 import com.kuit.findyou.global.common.exception.UserNotFoundException;
 import lombok.Getter;
@@ -77,4 +77,19 @@ public class UserService {
         return interestProtectingReportRepository.existsByUserIdAndProtectingReportId(userId, protectingReportId);
     }
 
+    public void removeInterestProtectingAnimal(Long userId, Long interestId) {
+        InterestProtectingReport interest = interestProtectingReportRepository.findById(interestId).orElseThrow(() -> new InterestAnimalNotFoundException(INTEREST_ANIMAL_NOT_FOUND));
+        if (interest.getUser().getId() != userId){
+            throw new UnauthorizedUserException(UNATHORIZED_USER);
+        }
+        interestProtectingReportRepository.delete(interest);
+    }
+
+    public void removeInterestReportAnimal(Long userId, Long interestId) {
+        InterestReport interest = interestReportRepository.findById(interestId).orElseThrow(() -> new InterestAnimalNotFoundException(INTEREST_ANIMAL_NOT_FOUND));
+        if(interest.getUser().getId() != userId){
+            throw new UnauthorizedUserException(UNATHORIZED_USER);
+        }
+        interestReportRepository.delete(interest);
+    }
 }

--- a/src/main/java/com/kuit/findyou/domain/user/service/UserService.java
+++ b/src/main/java/com/kuit/findyou/domain/user/service/UserService.java
@@ -22,8 +22,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
-
 import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.*;
 
 @Slf4j
@@ -86,8 +84,9 @@ public class UserService {
         if (interest.getUser().getId() != userId){
             throw new UnauthorizedUserException(UNATHORIZED_USER);
         }
-        User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));
-        user.removeInterestProtectingReport(interest);
+        if(!userRepository.existsById(userId)){
+            throw new UserNotFoundException(USER_NOT_FOUND);
+        }
         interestProtectingReportRepository.delete(interest);
     }
 
@@ -96,8 +95,9 @@ public class UserService {
         if(interest.getUser().getId() != userId){
             throw new UnauthorizedUserException(UNATHORIZED_USER);
         }
-        User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));
-        user.removeInterestReport(interest);
+        if(!userRepository.existsById(userId)){
+            throw new UserNotFoundException(USER_NOT_FOUND);
+        }
         interestReportRepository.delete(interest);
     }
 }

--- a/src/main/java/com/kuit/findyou/global/common/exception/UnauthorizedUserException.java
+++ b/src/main/java/com/kuit/findyou/global/common/exception/UnauthorizedUserException.java
@@ -1,0 +1,15 @@
+package com.kuit.findyou.global.common.exception;
+
+import com.kuit.findyou.global.common.response.status.ResponseStatus;
+import lombok.Getter;
+
+@Getter
+public class UnauthorizedUserException extends RuntimeException {
+
+    private final ResponseStatus exceptionStatus;
+
+    public UnauthorizedUserException(ResponseStatus exceptionStatus) {
+        super(exceptionStatus.getMessage());
+        this.exceptionStatus = exceptionStatus;
+    }
+}

--- a/src/main/java/com/kuit/findyou/global/common/exception_handler/GlobalControllerAdvice.java
+++ b/src/main/java/com/kuit/findyou/global/common/exception_handler/GlobalControllerAdvice.java
@@ -2,6 +2,7 @@ package com.kuit.findyou.global.common.exception_handler;
 
 import com.kuit.findyou.global.common.exception.BadRequestException;
 import com.kuit.findyou.global.common.exception.ReportNotFoundException;
+import com.kuit.findyou.global.common.exception.UnauthorizedUserException;
 import com.kuit.findyou.global.common.exception.UserNotFoundException;
 import com.kuit.findyou.global.common.response.BaseErrorResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -49,11 +50,20 @@ public class GlobalControllerAdvice {
         log.error("[handle_UsertNotFoundException]", e);
         return new BaseErrorResponse(USER_NOT_FOUND);
     }
+
     // 글이 존재하지 않는 경우
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(ReportNotFoundException.class)
     public BaseErrorResponse handle_ReportNotFoundException(Exception e) {
         log.error("[handle_ReportNotFoundException]", e);
         return new BaseErrorResponse(REPORT_NOT_FOUND);
+    }
+
+    // 유저에게 권한이 존재하지 않는 경우
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ExceptionHandler(UnauthorizedUserException.class)
+    public BaseErrorResponse handle_UnauthorizedUserException(Exception e) {
+        log.error("[handle_UnauthorizedUserException]", e);
+        return new BaseErrorResponse(UNATHORIZED_USER);
     }
 }

--- a/src/main/java/com/kuit/findyou/global/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/kuit/findyou/global/common/response/status/BaseExceptionResponseStatus.java
@@ -14,6 +14,8 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     REPORT_NOT_FOUND(40000, "존재하지 않는 글입니다."),
     ALREADY_SAVED_INTEREST_REPORT(40000, "이미 관심글로 등록되었습니다."),
 
+    INTEREST_ANIMAL_NOT_FOUND(40400, "존재하지 않는 관심동물입니다."),
+    UNATHORIZED_USER(40100,  "권한이 없는 사용자의 요청입니다."),
 
     INTERNAL_SERVER_ERROR(50000, "서버 내부 오류입니다.");
 

--- a/src/test/java/com/kuit/findyou/user/UserServiceTest.java
+++ b/src/test/java/com/kuit/findyou/user/UserServiceTest.java
@@ -63,6 +63,9 @@ public class UserServiceTest {
     @Autowired
     private InterestProtectingReportRepository interestProtectingReportRepository;
 
+   @Autowired
+   private EntityManager em;
+
     @Test
     void saveInterestProtectingAnimalTest(){
         // given
@@ -241,6 +244,10 @@ public class UserServiceTest {
 
         // when
         userService.removeInterestReportAnimal(savedUserId, savedInterestId2);
+
+        em.flush(); em.clear();
+
+
         Optional<InterestReport> interestReportById = interestReportRepository.findById(savedInterestId2);
         Optional<User> userById = userRepository.findById(savedUserId);
 
@@ -344,6 +351,9 @@ public class UserServiceTest {
 
         // when
         userService.removeInterestProtectingAnimal(userId, interestProtectingId);
+
+        em.flush(); em.clear();
+
         User foundUser = userRepository.findById(userId).get();
         boolean exists = interestProtectingReportRepository.existsById(interestProtectingId);
 


### PR DESCRIPTION
## Related issue 🛠
- closed #31

## Work Description 📝
- 관심 동물 등록을 해제하는 기능을 구현했습니다

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
- 없습니다.

## To Reviewers 📢

고민사항
-  원래는 보호중동물과 신고동물을 등록하는 API를 하나로 제공할 계획이었습니다. 근데 등록 해제 API를 구현하다보니 하나의 API에서 처리하는 것은 한 Rest API가 자원을 정확히 가리키지 못한다는 단점이 있고, 유지보수에 도움이 되지 않는 것 같다는 생각이 들었어요. 그래서 보호중 동물과 신고동물을 따로 처리하기 위해서 2개의 API로 분리했습니다. 그래서 등록 API도 등록 해제 API처럼 보호중동물과 신고동물을 따로 처리하도록 분리할까 하는데 다른 분들은 어떻게 생각하시나요?

트러블슈팅
- interestReportRepository의 delete()로 InterestReport를 삭제한 후에 findById()로 User를 확인해보니, User의 interestReports 컬렉션에 삭제한 interestReport가 남아 있는 현상을 발견했습니다. 그래서 관심동물을 해제할 때 User의 컬렉션에서도 삭제할 객체를 제외하는 로직을 추가했는데, 혹시 다른 방법이 있는지 아시나요?