### PR TITLE
[Feat] 마이 페이지 - 닉네임 수정

### DIFF
--- a/src/main/java/com/kuit/findyou/domain/auth/model/User.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/model/User.java
@@ -110,4 +110,8 @@ public class User extends BaseEntity {
 
         return false;
     }
+
+    public void changeName(String newNickname) {
+        this.name = newNickname;
+    }
 }

--- a/src/main/java/com/kuit/findyou/domain/report/dto/Card.java
+++ b/src/main/java/com/kuit/findyou/domain/report/dto/Card.java
@@ -23,7 +23,10 @@ public class Card {
     public static Card newInstanceFromReportWithUser(Report report, User loginedUser) {
         return Card.builder()
                 .cardId(report.getId())
-                .thumbnailImageUrl("1")   // image 관련 로직이 아직 없어서 임시로 넣은 데이터
+                .thumbnailImageUrl(
+                        (report.getImages() == null || report.getImages().isEmpty())
+                        ? null : report.getImages().get(0).getFilePath()
+                )
                 .title(report.getReportAnimal().getBreed().getName())
                 .tag(report.getTag())
                 .date(report.getEventDate().toString())

--- a/src/main/java/com/kuit/findyou/domain/report/dto/ProtectingReportInfoDTO.java
+++ b/src/main/java/com/kuit/findyou/domain/report/dto/ProtectingReportInfoDTO.java
@@ -33,7 +33,7 @@ public class ProtectingReportInfoDTO {
 
     public static ProtectingReportInfoDTO newInstanceFromProtectingReportWithUser(ProtectingReport protectingReport, User loginedUser) {
         return ProtectingReportInfoDTO.builder()
-                .imageUrl("image1.jpg")   // 더미 데이터 삽입
+                .imageUrl(protectingReport.getImageUrl())
                 .breed(protectingReport.getBreed())
                 .tag(ReportTag.PROTECTING.getValue())
                 .age(protectingReport.getAgeWithYear())

--- a/src/main/java/com/kuit/findyou/domain/report/dto/ReportInfoDTO.java
+++ b/src/main/java/com/kuit/findyou/domain/report/dto/ReportInfoDTO.java
@@ -1,6 +1,7 @@
 package com.kuit.findyou.domain.report.dto;
 
 import com.kuit.findyou.domain.auth.model.User;
+import com.kuit.findyou.domain.report.model.Image;
 import com.kuit.findyou.domain.report.model.Report;
 import com.kuit.findyou.domain.report.model.ReportAnimal;
 import com.kuit.findyou.domain.report.model.ReportedAnimalFeature;
@@ -9,12 +10,14 @@ import lombok.Getter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Builder
 public class ReportInfoDTO {
 
-    private List<String> imageUrls;
+    @Builder.Default
+    private List<String> imageUrls = null;
     private String tag;
     private String breed;
     private String furColor;
@@ -33,7 +36,7 @@ public class ReportInfoDTO {
 
         // 동물 특징 정보들
         List<String> animalFeatureList = new ArrayList<>();
-        for(ReportedAnimalFeature reportedAnimalFeature : reportAnimal.getReportedAnimalFeatures()) {
+        for (ReportedAnimalFeature reportedAnimalFeature : reportAnimal.getReportedAnimalFeatures()) {
             animalFeatureList.add(reportedAnimalFeature.getFeature().getFeatureValue());
         }
 
@@ -42,13 +45,11 @@ public class ReportInfoDTO {
 
         Boolean interest = loginedUser.isInterestReport(report.getId());
 
-        List<String> tempImages = new ArrayList<>();  // 이미지 관련 로직이 아직 없어서 더미 데이터 삽입
-        tempImages.add("image1.jpg");
-        tempImages.add("image2.jpg");
-        tempImages.add("image3.jpg");
-
         return ReportInfoDTO.builder()
-                .imageUrls(tempImages)   // 더미 데이터임
+                .imageUrls(
+                        report.getImages().stream()     // Image 리스트를 받아서 FilePath를 반환
+                                .map(Image::getFilePath)
+                                .collect(Collectors.toList()))
                 .tag(report.getTag())
                 .breed(reportAnimal.getBreed().getSpeciesAndBreed())
                 .furColor(reportAnimal.getFurColor())

--- a/src/main/java/com/kuit/findyou/domain/report/dto/ReportInfoDTO.java
+++ b/src/main/java/com/kuit/findyou/domain/report/dto/ReportInfoDTO.java
@@ -19,6 +19,7 @@ public class ReportInfoDTO {
     @Builder.Default
     private List<String> imageUrls = null;
     private String tag;
+    private String sex;
     private String breed;
     private String furColor;
     private String userName;
@@ -51,6 +52,7 @@ public class ReportInfoDTO {
                                 .map(Image::getFilePath)
                                 .collect(Collectors.toList()))
                 .tag(report.getTag())
+                .sex(reportAnimal.getSex())
                 .breed(reportAnimal.getBreed().getSpeciesAndBreed())
                 .furColor(reportAnimal.getFurColor())
                 .userName(reportUser.getName())

--- a/src/main/java/com/kuit/findyou/domain/report/dto/ReportInfoDTO.java
+++ b/src/main/java/com/kuit/findyou/domain/report/dto/ReportInfoDTO.java
@@ -21,7 +21,7 @@ public class ReportInfoDTO {
     private String userName;
     private String writeDate;
     private String eventDate;
-    private String foundLocation;
+    private String eventLocation;
     private List<String> features;
     private String additionalDescription;
     private Boolean interest;
@@ -55,7 +55,7 @@ public class ReportInfoDTO {
                 .userName(reportUser.getName())
                 .writeDate(report.getCreatedAt().toLocalDate().toString())
                 .eventDate(report.getEventDate().toString())
-                .foundLocation(report.getEventLocation())
+                .eventLocation(report.getEventLocation())
                 .features(animalFeatureList)
                 .additionalDescription(report.getAdditionalDescription())
                 .interest(interest)

--- a/src/main/java/com/kuit/findyou/domain/report/model/Breed.java
+++ b/src/main/java/com/kuit/findyou/domain/report/model/Breed.java
@@ -28,6 +28,6 @@ public class Breed extends BaseEntity {
 
     // [개]웰시코기 와 같이 축종 + 품종을 반환하는 메서드
     public String getSpeciesAndBreed() {
-        return "[" + species + "]" + name;
+        return "[" + species + "] " + name;
     }
 }

--- a/src/main/java/com/kuit/findyou/domain/report/model/Report.java
+++ b/src/main/java/com/kuit/findyou/domain/report/model/Report.java
@@ -72,7 +72,7 @@ public class Report extends BaseEntity {
         report.additionalDescription = additionalDescription;
         report.setUser(user);
         report.reportAnimal = reportAnimal;
-        if(images != null && images.isEmpty()) {
+        if(images != null && !images.isEmpty()) {
             images.forEach(report::addImage);
         }
         return report;

--- a/src/main/java/com/kuit/findyou/domain/report/model/Report.java
+++ b/src/main/java/com/kuit/findyou/domain/report/model/Report.java
@@ -72,7 +72,7 @@ public class Report extends BaseEntity {
         report.additionalDescription = additionalDescription;
         report.setUser(user);
         report.reportAnimal = reportAnimal;
-        if(images != null && images.size() != 0) {
+        if(images != null && images.isEmpty()) {
             images.forEach(report::addImage);
         }
         return report;

--- a/src/main/java/com/kuit/findyou/domain/report/service/AnimalRetrieveService.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/AnimalRetrieveService.java
@@ -8,6 +8,7 @@ import com.kuit.findyou.domain.report.model.ProtectingReport;
 import com.kuit.findyou.domain.report.model.Report;
 import com.kuit.findyou.domain.report.repository.ProtectingReportRepository;
 import com.kuit.findyou.domain.report.repository.ReportRepository;
+import com.kuit.findyou.global.common.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -16,6 +17,8 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+
+import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.USER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -49,7 +52,7 @@ public class AnimalRetrieveService {
             String location) {
 
         User loginedUser = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+                .orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));
 
         Slice<ProtectingReport> protectingReportSlice = protectingReportRepository.findProtectingReportWithFilters(lastProtectId,startDate, endDate, species, breeds, location, PageRequest.of(0, 20));
         List<ProtectingReport> protectingReportList = protectingReportSlice.getContent();

--- a/src/main/java/com/kuit/findyou/domain/report/service/ProtectingAnimalInfoService.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/ProtectingAnimalInfoService.java
@@ -7,9 +7,14 @@ import com.kuit.findyou.domain.report.model.ProtectingReport;
 import com.kuit.findyou.domain.report.model.ViewedProtectingReport;
 import com.kuit.findyou.domain.report.repository.ProtectingReportRepository;
 import com.kuit.findyou.domain.report.repository.ViewedProtectingReportRepository;
+import com.kuit.findyou.global.common.exception.ReportNotFoundException;
+import com.kuit.findyou.global.common.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.REPORT_NOT_FOUND;
+import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.USER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -23,12 +28,10 @@ public class ProtectingAnimalInfoService {
     @Transactional
     public ProtectingReportInfoDTO findProtectingReportInfoById(Long protectingReportId, Long userId) {
         ProtectingReport protectingReport = protectingReportRepository.findById(protectingReportId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 보호글입니다."));   // 커스텀 예외로 바꿀수도
+                .orElseThrow(() -> new ReportNotFoundException(REPORT_NOT_FOUND));
 
         User loginedUser = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));    // 커스텀 예외로 바꿀수도
-
-
+                .orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));
 
 
         // 마지막에 본 것만 등록되도록 하기 위해, 기존에 동일한 보호글을 본 적이 있다면, 해당 정보를 삭제

--- a/src/main/java/com/kuit/findyou/domain/report/service/ProtectingAnimalRetrieveService.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/ProtectingAnimalRetrieveService.java
@@ -6,6 +6,7 @@ import com.kuit.findyou.domain.report.dto.Card;
 import com.kuit.findyou.domain.report.dto.ProtectingReportCardDTO;
 import com.kuit.findyou.domain.report.model.ProtectingReport;
 import com.kuit.findyou.domain.report.repository.ProtectingReportRepository;
+import com.kuit.findyou.global.common.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -13,6 +14,8 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.util.List;
+
+import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.USER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -53,7 +56,7 @@ public class ProtectingAnimalRetrieveService {
             String location) {
 
         User loginedUser = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+                .orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));
 
         Slice<ProtectingReport> protectingReportSlice = protectingReportRepository.findProtectingReportWithFilters(lastProtectId, startDate, endDate, species, breeds, location, PageRequest.of(0, 20));
 

--- a/src/main/java/com/kuit/findyou/domain/report/service/ReportAnimalInfoService.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/ReportAnimalInfoService.java
@@ -5,9 +5,14 @@ import com.kuit.findyou.domain.auth.repository.UserRepository;
 import com.kuit.findyou.domain.report.dto.ReportInfoDTO;
 import com.kuit.findyou.domain.report.model.*;
 import com.kuit.findyou.domain.report.repository.*;
+import com.kuit.findyou.global.common.exception.ReportNotFoundException;
+import com.kuit.findyou.global.common.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.REPORT_NOT_FOUND;
+import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.USER_NOT_FOUND;
 
 @Slf4j
 @Service
@@ -22,12 +27,12 @@ public class ReportAnimalInfoService {
 
         // 인자로 넘어온 id 에 맞는 신고글 정보
         Report report = reportRepository.findById(reportId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 신고글입니다."));  // 커스텀 예외로 바꿀수도
+                .orElseThrow(() -> new ReportNotFoundException(REPORT_NOT_FOUND));  // 커스텀 예외로 바꿀수도
 
 
         // 현재 로그인중인 유저 정보
         User loginedUser = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));    // 커스텀 예외로 바꿀수도
+                .orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));    // 커스텀 예외로 바꿀수도
 
 
         // 마지막에 본 것만 등록되도록 하기 위해, 기존에 동일한 보호글을 본 적이 있다면, 해당 정보를 삭제

--- a/src/main/java/com/kuit/findyou/domain/report/service/ReportAnimalRetrieveService.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/ReportAnimalRetrieveService.java
@@ -6,6 +6,7 @@ import com.kuit.findyou.domain.report.dto.Card;
 import com.kuit.findyou.domain.report.dto.ReportCardDTO;
 import com.kuit.findyou.domain.report.model.Report;
 import com.kuit.findyou.domain.report.repository.ReportRepository;
+import com.kuit.findyou.global.common.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -13,6 +14,8 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.util.List;
+
+import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.USER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -51,7 +54,7 @@ public class ReportAnimalRetrieveService {
             String location) {
 
         User loginedUser = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+                .orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));
 
         Slice<Report> reportSlice = reportRepository.findReportsWithFilters(lastReportId, startDate, endDate, species, breeds, location, PageRequest.of(0, 20));
 

--- a/src/main/java/com/kuit/findyou/domain/user/controller/UserController.java
+++ b/src/main/java/com/kuit/findyou/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.kuit.findyou.domain.user.controller;
 
 import com.kuit.findyou.domain.home.dto.ReportTag;
+import com.kuit.findyou.domain.user.dto.NewNicknameRequest;
 import com.kuit.findyou.domain.user.dto.PostInterestAnimalRequest;
 import com.kuit.findyou.domain.user.service.UserService;
 import com.kuit.findyou.global.common.exception.BadRequestException;
@@ -47,6 +48,15 @@ public class UserController {
         log.info("[deleteInterestReportAnimal] id = {}", reportId);
         Long userId = 1L;
         userService.removeInterestReportAnimal(userId, reportId);
+        return new BaseResponse<>(null);
+    }
+
+    @PatchMapping("/nickname")
+    public BaseResponse<Long> updateNickname(@RequestBody NewNicknameRequest newNickname) {
+        // 토큰 구현이 안된 상태라서 미리 저장된 사용자 활용
+        Long userId = 1L;
+        userService.updateNickname(userId, newNickname.getNewNickname());
+
         return new BaseResponse<>(null);
     }
 

--- a/src/main/java/com/kuit/findyou/domain/user/dto/NewNicknameRequest.java
+++ b/src/main/java/com/kuit/findyou/domain/user/dto/NewNicknameRequest.java
@@ -1,0 +1,12 @@
+package com.kuit.findyou.domain.user.dto;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class NewNicknameRequest {
+
+    private String newNickname;
+}

--- a/src/main/java/com/kuit/findyou/domain/user/service/UserService.java
+++ b/src/main/java/com/kuit/findyou/domain/user/service/UserService.java
@@ -62,7 +62,7 @@ public class UserService {
 
     @Transactional
     public void updateNickname(Long userId, String newNickname) {
-        User loginedUser = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));
+        User loginedUser = findUser(userId);
 
         loginedUser.changeName(newNickname);
     }

--- a/src/main/java/com/kuit/findyou/domain/user/service/UserService.java
+++ b/src/main/java/com/kuit/findyou/domain/user/service/UserService.java
@@ -16,11 +16,11 @@ import com.kuit.findyou.domain.user.exception.InterestAnimalNotFoundException;
 import com.kuit.findyou.global.common.exception.UnauthorizedUserException;
 import com.kuit.findyou.global.common.exception.ReportNotFoundException;
 import com.kuit.findyou.global.common.exception.UserNotFoundException;
-import jakarta.transaction.Transactional;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.*;
 
@@ -57,6 +57,14 @@ public class UserService {
         InterestReport interestReport = InterestReport.createInterestReport(user, report);
         InterestReport saved = interestReportRepository.save(interestReport);
         return saved.getId();
+    }
+
+
+    @Transactional
+    public void updateNickname(Long userId, String newNickname) {
+        User loginedUser = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));
+
+        loginedUser.changeName(newNickname);
     }
 
     private Report findReport(PostInterestAnimalRequest request) {

--- a/src/test/java/com/kuit/findyou/domain/report/service/ProtectingAnimalInfoServiceTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/service/ProtectingAnimalInfoServiceTest.java
@@ -98,7 +98,7 @@ class ProtectingAnimalInfoServiceTest {
         assertThat(findUser2.getViewedProtectingReports()).size().isEqualTo(1);
 
         for (ViewedProtectingReport protectingReport : findUser2.getViewedProtectingReports()) {
-            log.info("protectingReport.id = {}", protectingReport.getId());
+            log.info("protectingReport.imageUrl = {}", protectingReport.getProtectingReport().getImageUrl());
         }
 
 

--- a/src/test/java/com/kuit/findyou/domain/report/service/ReportAnimalInfoServiceTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/service/ReportAnimalInfoServiceTest.java
@@ -7,9 +7,12 @@ import com.kuit.findyou.domain.report.model.*;
 import com.kuit.findyou.domain.report.repository.*;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +25,7 @@ import java.util.UUID;
 
 @SpringBootTest
 @Transactional
+@Slf4j
 class ReportAnimalInfoServiceTest {
 
     // Report, ReportAnimal, ReportedAnimalFeature, AnimalFeature, User
@@ -124,6 +128,10 @@ class ReportAnimalInfoServiceTest {
         User findUser2 = userRepository.findById(userId).get();
 
         Assertions.assertThat(findUser2.getViewedReports()).size().isEqualTo(1);
+
+        for (String imageUrl : reportInfo.getImageUrls()) {
+            log.info("imageUrl : {}", imageUrl);
+        }
     }
 
 }

--- a/src/test/java/com/kuit/findyou/user/UserServiceTest.java
+++ b/src/test/java/com/kuit/findyou/user/UserServiceTest.java
@@ -8,24 +8,22 @@ import com.kuit.findyou.domain.report.repository.*;
 import com.kuit.findyou.domain.user.dto.PostInterestAnimalRequest;
 import com.kuit.findyou.domain.user.exception.AlreadySavedInterestException;
 import com.kuit.findyou.domain.user.service.UserService;
-import com.kuit.findyou.global.common.exception.BadRequestException;
 import com.kuit.findyou.global.common.exception.ReportNotFoundException;
 import com.kuit.findyou.global.common.exception.UserNotFoundException;
 import jakarta.persistence.EntityManager;
-import jakarta.transaction.Transactional;
 import org.assertj.core.api.Assertions;
+import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
-import javax.swing.text.html.parser.Entity;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -60,14 +58,15 @@ public class UserServiceTest {
     @Autowired
     private InterestReportRepository interestReportRepository;
 
+    @PersistenceContext
+    private EntityManager em;
+
     @Autowired
     private InterestProtectingReportRepository interestProtectingReportRepository;
 
-   @Autowired
-   private EntityManager em;
 
     @Test
-    void saveInterestProtectingAnimalTest(){
+    void saveInterestProtectingAnimalTest() {
         // given
         User user = User.builder()
                 .name("홍길동")
@@ -123,7 +122,7 @@ public class UserServiceTest {
     }
 
     @Test
-    void saveInterestReportAnimalTest(){
+    void saveInterestReportAnimalTest() {
         // given
         User user = User.builder()
                 .name("홍길동")
@@ -188,8 +187,10 @@ public class UserServiceTest {
 
     @Test
     @DisplayName("관심 신고동물 삭제 테스트")
-    void removeInterestReportAnimalTest(){
+    void removeInterestReportAnimalTest() {
         // given
+
+        //given
         User user = User.builder()
                 .name("홍길동")
                 .email("email@email")
@@ -245,7 +246,8 @@ public class UserServiceTest {
         // when
         userService.removeInterestReportAnimal(savedUserId, savedInterestId2);
 
-        em.flush(); em.clear();
+        em.flush();
+        em.clear();
 
 
         Optional<InterestReport> interestReportById = interestReportRepository.findById(savedInterestId2);
@@ -258,7 +260,7 @@ public class UserServiceTest {
 
     @Test
     @DisplayName("관심 보호중 동물 삭제")
-    void removeInterestProtectingReport(){
+    void removeInterestProtectingReport() {
         // given
         User user = User.builder()
                 .name("홍길동")
@@ -352,7 +354,8 @@ public class UserServiceTest {
         // when
         userService.removeInterestProtectingAnimal(userId, interestProtectingId);
 
-        em.flush(); em.clear();
+        em.flush();
+        em.clear();
 
         User foundUser = userRepository.findById(userId).get();
         boolean exists = interestProtectingReportRepository.existsById(interestProtectingId);
@@ -360,5 +363,28 @@ public class UserServiceTest {
         // then
         Assertions.assertThat(foundUser.getInterestProtectingReports()).hasSize(2);
         Assertions.assertThat(exists).isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("닉네임 변경 테스트")
+    void updateNickname() {
+        User user = User.builder()
+                .name("홍길동")
+                .email("email@email")
+                .password("password")
+                .profileImageUrl("image.png")
+                .build();
+
+        User savedUser = userRepository.save(user);
+
+        // when
+        userService.updateNickname(savedUser.getId(), "아무개");
+
+        em.flush();
+        em.clear();
+
+        // then
+        User findUser = userRepository.findById(savedUser.getId()).get();
+        assertThat(findUser.getName()).isEqualTo("아무개");
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #32 

## Work Description 📝
- 커스텀 예외 적용
- 신고글, 보호글 상세 조회 시 이미지 관련 더미데이터를 넣어주었던 걸 실제로 객체에서 이미지를 꺼내오는 로직으로 변경. (다만 현재는 filePath만 반환하는 형태)
- 신고글 이미지가 null로 설정된 경우에 대한 예외처리 추가
- 닉네임 변경 로직 구현

## Screenshot 📸

## Uncompleted Tasks 😅
- 없습니다

## To Reviewers 📢
확인 부탁드립니다!

추가적으로 data 를 null로 반환 시 서버측 설정에 의해 "data" : null 형태가 아니라 아예 data 정보는 반환되지 않는 형태인데 이 부분은 어떻게 할까요?

