### PR TITLE
[Feat] 구조 동물 공공데이터 API 활용 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,9 @@ dependencies {
     implementation platform('com.amazonaws:aws-java-sdk-bom:1.11.1000')
     implementation 'com.amazonaws:aws-java-sdk-s3'
 
+    // WebFlux
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kuit/findyou/FindyouApplication.java
+++ b/src/main/java/com/kuit/findyou/FindyouApplication.java
@@ -3,9 +3,11 @@ package com.kuit.findyou;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling  // 이걸 설정해줘야함
 public class FindyouApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/kuit/findyou/domain/api/controller/ProtectAnimalApiController.java
+++ b/src/main/java/com/kuit/findyou/domain/api/controller/ProtectAnimalApiController.java
@@ -1,6 +1,6 @@
 package com.kuit.findyou.domain.api.controller;
 
-import com.kuit.findyou.domain.api.service.ProtectAnimalApiService;
+import com.kuit.findyou.domain.api.service.ProtectAnimalApiUtil;
 import com.kuit.findyou.global.common.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,10 +10,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ProtectAnimalApiController {
 
-    private final ProtectAnimalApiService protectAnimalApiService;
+    private final ProtectAnimalApiUtil protectAnimalApiService;
 
     @GetMapping("/api/v1/initDatabase")
-    public BaseResponse<Void> getAbandonmentData() {
+    public BaseResponse<Void> initDatabase() {
 
         protectAnimalApiService.updateAllProtectingReports();
 

--- a/src/main/java/com/kuit/findyou/domain/api/controller/ProtectAnimalApiController.java
+++ b/src/main/java/com/kuit/findyou/domain/api/controller/ProtectAnimalApiController.java
@@ -1,0 +1,22 @@
+package com.kuit.findyou.domain.api.controller;
+
+import com.kuit.findyou.domain.api.service.ProtectAnimalApiService;
+import com.kuit.findyou.global.common.response.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ProtectAnimalApiController {
+
+    private final ProtectAnimalApiService protectAnimalApiService;
+
+    @GetMapping("/api/v1/initDatabase")
+    public BaseResponse<Void> getAbandonmentData() {
+
+        protectAnimalApiService.updateAllProtectingReports();
+
+        return new BaseResponse<>(null);
+    }
+}

--- a/src/main/java/com/kuit/findyou/domain/api/dto/ProtectAnimalApiResponse.java
+++ b/src/main/java/com/kuit/findyou/domain/api/dto/ProtectAnimalApiResponse.java
@@ -22,16 +22,16 @@ public class ProtectAnimalApiResponse {
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class Response {
         @JsonProperty("header")
-        private AbandonmentResponseHeader header;
+        private ProtectAnimalApiResponseHeader header;
 
         @JsonProperty("body")
-        private AbandonmentResponseBody body;
+        private ProtectAnimalApiResponseBody body;
     }
 
 
     @Getter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class AbandonmentResponseHeader {
+    public static class ProtectAnimalApiResponseHeader {
         @JsonProperty("reqNo")
         private String requestNumber;
 
@@ -44,7 +44,7 @@ public class ProtectAnimalApiResponse {
 
     @Getter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class AbandonmentResponseBody {
+    public static class ProtectAnimalApiResponseBody {
         @JsonProperty("items")
         private Items items;
     }

--- a/src/main/java/com/kuit/findyou/domain/api/dto/ProtectAnimalApiResponse.java
+++ b/src/main/java/com/kuit/findyou/domain/api/dto/ProtectAnimalApiResponse.java
@@ -1,0 +1,185 @@
+package com.kuit.findyou.domain.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProtectAnimalApiResponse {
+
+    @JsonProperty("response")
+    private Response response;
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class Response {
+        @JsonProperty("header")
+        private AbandonmentResponseHeader header;
+
+        @JsonProperty("body")
+        private AbandonmentResponseBody body;
+    }
+
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class AbandonmentResponseHeader {
+        @JsonProperty("reqNo")
+        private String requestNumber;
+
+        @JsonProperty("resultCode")
+        private String resultCode;
+
+        @JsonProperty("resultMsg")
+        private String resultMessage;
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class AbandonmentResponseBody {
+        @JsonProperty("items")
+        private Items items;
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class Items {
+        @JsonProperty("item")
+        private List<Item> item;
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class Item {
+        @JsonProperty("desertionNo")
+        private String desertionNo;  // 유기 번호
+
+        @JsonProperty("filename")
+        private String filename;     // 작은 이미지
+
+        @JsonProperty("happenDt")
+        private String happenDt;     // 접수일
+
+        @JsonProperty("happenPlace")
+        private String happenPlace;  // 발견장소
+
+        @JsonProperty("kindCd")
+        private String kindCd;       // 품종 - [개] 믹스견
+
+        @JsonProperty("colorCd")
+        private String colorCd;      // 색상 - 흰색&검은색
+
+        @JsonProperty("age")
+        private String age;          // 나이 - 2019(년생)
+
+        @JsonProperty("weight")
+        private String weight;       // 몸무게 - 0.69(Kg)
+
+        @JsonProperty("noticeNo")
+        private String noticeNo;     // 공고 번호
+
+        @JsonProperty("noticeSdt")
+        private String noticeSdt;    // 공고 시작일
+
+        @JsonProperty("noticeEdt")
+        private String noticeEdt;    // 공고 종료일
+
+        @JsonProperty("popfile")
+        private String popfile;      // 큰 이미지
+
+        @JsonProperty("processState")
+        private String processState; // 상태
+
+        @JsonProperty("sexCd")
+        private String sexCd;        // 성별
+
+        @JsonProperty("neuterYn")
+        private String neuterYn;     // 중성화 여부
+
+        @JsonProperty("specialMark")
+        private String specialMark;  // 특징
+
+        @JsonProperty("careNm")
+        private String careNm;       // 보호소 이름
+
+        @JsonProperty("careTel")
+        private String careTel;      // 보호소 전화번호
+
+        @JsonProperty("careAddr")
+        private String careAddr;     // 보호 장소
+
+        @JsonProperty("orgNm")
+        private String orgNm;        // 관할 기관
+
+        @JsonProperty("chargeNm")
+        private String chargeNm;     // 담당자
+
+        @JsonProperty("officetel")
+        private String officetel;    // 담당자연락처
+
+
+        public String extractBreed() {
+            // 첫 번째 공백의 위치를 찾음
+            int firstSpaceIndex = kindCd.indexOf(" ");
+
+            // 공백이 없거나 마지막 문자가 공백인 경우 빈 문자열 반환
+            if (firstSpaceIndex == -1 || firstSpaceIndex == kindCd.length() - 1) {
+                return "";
+            }
+
+            // 첫 번째 공백 이후의 모든 문자열을 그대로 가져와서 반환
+            return kindCd.substring(firstSpaceIndex + 1);
+        }
+
+        public String extractSpecies() {
+            // 대괄호 안의 내용만 추출하는 정규식
+            String regex = "\\[(.*?)\\]";
+
+            Pattern pattern = Pattern.compile(regex);
+            Matcher matcher = pattern.matcher(kindCd);
+
+            if (matcher.find()) {
+                return matcher.group(1);  // 매칭된 그룹을 반환
+            } else {
+                return "";  // 매칭되지 않으면 빈 문자열 반환
+            }
+        }
+
+
+        public String extractYear() {
+            // 숫자와 괄호 이전의 연도만 추출
+            return age.split("\\(")[0].trim();// 불필요한 공백을 제거
+        }
+
+
+        public String extractWeight() {
+            // 괄호 이전의 몸무게만 추출
+            String weight = this.weight.split("\\(")[0]; // "("를 기준으로 분리하고, 첫 번째 부분인 몸무게를 반환
+
+            return weight.replace(',', '.').trim(); // 불필요한 공백을 제거
+        }
+
+
+        public String extractFurColor() {
+            // &를 , 로 대체
+            return colorCd.replace("&", ", ");
+        }
+
+
+        public LocalDate changeToLocalDate(String date) {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+            return LocalDate.parse(date, formatter);
+        }
+
+    }
+
+}

--- a/src/main/java/com/kuit/findyou/domain/api/service/ProtectAnimalApiService.java
+++ b/src/main/java/com/kuit/findyou/domain/api/service/ProtectAnimalApiService.java
@@ -1,0 +1,165 @@
+package com.kuit.findyou.domain.api.service;
+
+import com.kuit.findyou.domain.api.dto.ProtectAnimalApiResponse;
+import com.kuit.findyou.domain.report.model.Neutering;
+import com.kuit.findyou.domain.report.model.ProtectingReport;
+import com.kuit.findyou.domain.report.model.Sex;
+import com.kuit.findyou.domain.report.repository.ProtectingReportRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ProtectAnimalApiService {
+
+    private final ProtectingReportRepository protectingReportRepository;
+
+    private WebClient webClient;
+
+    private final String serviceKey = "Mqn0b2BWoDH7qfXyzuOIfwA5O9dj4Dt9yOBuB4vGVpyMo5HOM0USlNPSzV5A5hfB%2FUhfl2yQHbIbMGs2luskgA%3D%3D";
+
+    private static final String BASE_URL = "http://apis.data.go.kr/1543061/abandonmentPublicSrvc/abandonmentPublic";
+
+    public List<ProtectAnimalApiResponse.Item> getAllAbandonmentData(String bgnde, String endde, String state) {
+        DefaultUriBuilderFactory factory = new DefaultUriBuilderFactory(BASE_URL);
+        factory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY);
+
+        HttpClient httpClient = HttpClient.create()
+                .responseTimeout(Duration.ofSeconds(600));
+
+        webClient = WebClient.builder()
+                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(-1))
+                .uriBuilderFactory(factory)
+                .baseUrl(BASE_URL)
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+
+        List<ProtectAnimalApiResponse.Item> allData = new ArrayList<>();
+        int pageNo = 1;
+        int numOfRows = 1000; // 최대 개수
+
+        while (true) {
+            int finalPageNo = pageNo;
+            ProtectAnimalApiResponse response = webClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .queryParam("serviceKey", serviceKey)
+                            .queryParam("bgnde", bgnde)
+                            .queryParam("endde", endde)
+                            .queryParam("pageNo", finalPageNo)
+                            .queryParam("numOfRows", numOfRows)
+                            .queryParam("state", state)  // protect 아님 notice
+                            .queryParam("_type", "json")
+                            .build())
+                    .header("Accept", "application/json")
+                    .retrieve()
+                    .bodyToMono(ProtectAnimalApiResponse.class)
+                    .block();
+
+            if (response == null || response.getResponse().getBody().getItems().getItem() == null) {
+                break; // 데이터가 없을 경우 루프 종료
+            }
+
+            allData.addAll(response.getResponse().getBody().getItems().getItem());
+            pageNo++; // 다음 페이지 요청
+        }
+
+        return allData;
+    }
+
+    @Transactional
+    public void syncProtectingReports(String bgnde, String endde, String state) {
+        // 1. 외부 API에서 데이터 가져오기
+        List<ProtectAnimalApiResponse.Item> items = getAllAbandonmentData(bgnde, endde, state);
+
+        // 2. 외부 API에서 받은 모든 noticeNumber 추출
+        List<String> incomingNoticeNumbers = items.stream()
+                .map(ProtectAnimalApiResponse.Item::getNoticeNo)
+                .collect(Collectors.toList());
+
+        // 3. DB에 저장된 기존 ProtectingReport 중 데이터 조회
+        List<ProtectingReport> existingReports = protectingReportRepository.findByNoticeNumberIn(incomingNoticeNumbers);
+
+        // 4. 기존 DB에 있지만, 외부 API 데이터에 없는 데이터 삭제 -> 즉 공공 API에서 더이상 관리하지 않는 데이터는 DB에서도 삭제
+        List<ProtectingReport> toDelete = existingReports.stream()
+                .filter(report -> !incomingNoticeNumbers.contains(report.getNoticeNumber()))
+                .collect(Collectors.toList());
+        protectingReportRepository.deleteAll(toDelete);
+
+        // 5. 외부 API 데이터 중 DB에 없는 데이터만 필터링 -> 새롭게 추가된 데이터들
+        List<ProtectingReport> newReports = items.stream()
+                .filter(item -> existingReports.stream()
+                        .noneMatch(report -> report.getNoticeNumber().equals(item.getNoticeNo())))
+                .map(response -> ProtectingReport.builder()
+                        .happenDate(response.changeToLocalDate(response.getHappenDt()))
+                        .imageUrl(response.getPopfile())
+                        .species(response.extractSpecies())
+                        .noticeNumber(response.getNoticeNo())
+                        .noticeStartDate(response.changeToLocalDate(response.getNoticeSdt()))
+                        .noticeEndDate(response.changeToLocalDate(response.getNoticeEdt()))
+                        .breed(response.extractBreed())
+                        .furColor(response.extractFurColor())
+                        .weight(response.extractWeight())
+                        .age(response.extractYear())
+                        .sex(Sex.valueOf(response.getSexCd()))
+                        .neutering(Neutering.valueOf(response.getNeuterYn()))
+                        .foundLocation(response.getHappenPlace())
+                        .significant(response.getSpecialMark() == null ? "미등록" : response.getSpecialMark())
+                        .careName(response.getCareNm())
+                        .careAddr(response.getCareAddr())
+                        .careTel(response.getCareTel())
+                        .authority(response.getOrgNm())
+                        .authorityPhoneNumber(response.getOfficetel())
+                        .build())
+                .collect(Collectors.toList());
+
+        // 6. 새로운 데이터 저장
+        protectingReportRepository.saveAll(newReports);
+
+        log.info("DB 동기화 완료: 삭제된 데이터 = {}, 추가된 데이터 = {}", toDelete.size(), newReports.size());
+    }
+
+    @Transactional
+    public void updateProtectingReportWithProtectState() {
+        // state = protect 인 데이터 획득 및 update
+        syncProtectingReports("20220101", getCurrentDate(), "protect");
+    }
+
+    @Transactional
+    public void updateProtectingReportWithNoticeState() {
+        // state = notice 인 데이터 획득 및 update
+        syncProtectingReports(calculateStartDate("30"), getCurrentDate(), "notice");
+    }
+
+    @Scheduled(cron = "0 30 4 * * ?")    // 4시 30분으로 스케줄링 설정
+    @Transactional
+    public void updateAllProtectingReports() {
+        updateProtectingReportWithNoticeState();
+        updateProtectingReportWithProtectState();
+    }
+
+    private String calculateStartDate(String recentDays) {
+        // 날짜 계산 로직 (예: 최근 7일 등)
+        return LocalDate.now().minusDays(Long.parseLong(recentDays)).format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+    }
+
+    private String getCurrentDate() {
+        // 오늘 날짜 반환
+        return LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+    }
+}
+

--- a/src/main/java/com/kuit/findyou/domain/api/service/ProtectAnimalApiService.java
+++ b/src/main/java/com/kuit/findyou/domain/api/service/ProtectAnimalApiService.java
@@ -7,6 +7,7 @@ import com.kuit.findyou.domain.report.model.Sex;
 import com.kuit.findyou.domain.report.repository.ProtectingReportRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -31,7 +32,8 @@ public class ProtectAnimalApiService {
 
     private WebClient webClient;
 
-    private final String serviceKey = "Mqn0b2BWoDH7qfXyzuOIfwA5O9dj4Dt9yOBuB4vGVpyMo5HOM0USlNPSzV5A5hfB%2FUhfl2yQHbIbMGs2luskgA%3D%3D";
+    @Value("${api.serviceKey}")
+    private String serviceKey;
 
     private static final String BASE_URL = "http://apis.data.go.kr/1543061/abandonmentPublicSrvc/abandonmentPublic";
 

--- a/src/main/java/com/kuit/findyou/domain/api/service/ProtectAnimalApiUtil.java
+++ b/src/main/java/com/kuit/findyou/domain/api/service/ProtectAnimalApiUtil.java
@@ -148,7 +148,7 @@ public class ProtectAnimalApiUtil {
         syncProtectingReports(calculateStartDate("30"), getCurrentDate(), "notice");
     }
 
-    @Scheduled(cron = "0 33 3 * * ?")    // 4시 30분으로 스케줄링 설정
+    @Scheduled(cron = "0 30 4 * * ?")    // 4시 30분으로 스케줄링 설정
     @Transactional
     public void updateAllProtectingReports() {
         updateProtectingReportWithNoticeState();

--- a/src/main/java/com/kuit/findyou/domain/api/service/ProtectAnimalApiUtil.java
+++ b/src/main/java/com/kuit/findyou/domain/api/service/ProtectAnimalApiUtil.java
@@ -37,7 +37,7 @@ public class ProtectAnimalApiService {
 
     private static final String BASE_URL = "http://apis.data.go.kr/1543061/abandonmentPublicSrvc/abandonmentPublic";
 
-    public List<ProtectAnimalApiResponse.Item> getAllAbandonmentData(String bgnde, String endde, String state) {
+    public List<ProtectAnimalApiResponse.Item> getAllProtectAnimalApiData(String bgnde, String endde, String state) {
         DefaultUriBuilderFactory factory = new DefaultUriBuilderFactory(BASE_URL);
         factory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY);
 
@@ -86,7 +86,7 @@ public class ProtectAnimalApiService {
     @Transactional
     public void syncProtectingReports(String bgnde, String endde, String state) {
         // 1. 외부 API에서 데이터 가져오기
-        List<ProtectAnimalApiResponse.Item> items = getAllAbandonmentData(bgnde, endde, state);
+        List<ProtectAnimalApiResponse.Item> items = getAllProtectAnimalApiData(bgnde, endde, state);
 
         // 2. 외부 API에서 받은 모든 noticeNumber 추출
         List<String> incomingNoticeNumbers = items.stream()

--- a/src/main/java/com/kuit/findyou/domain/api/service/ProtectAnimalApiUtil.java
+++ b/src/main/java/com/kuit/findyou/domain/api/service/ProtectAnimalApiUtil.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -23,10 +24,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Service
+@Component
 @RequiredArgsConstructor
 @Slf4j
-public class ProtectAnimalApiService {
+public class ProtectAnimalApiUtil {
 
     private final ProtectingReportRepository protectingReportRepository;
 
@@ -147,7 +148,7 @@ public class ProtectAnimalApiService {
         syncProtectingReports(calculateStartDate("30"), getCurrentDate(), "notice");
     }
 
-    @Scheduled(cron = "0 30 4 * * ?")    // 4시 30분으로 스케줄링 설정
+    @Scheduled(cron = "0 33 3 * * ?")    // 4시 30분으로 스케줄링 설정
     @Transactional
     public void updateAllProtectingReports() {
         updateProtectingReportWithNoticeState();

--- a/src/main/java/com/kuit/findyou/domain/report/model/ProtectingReport.java
+++ b/src/main/java/com/kuit/findyou/domain/report/model/ProtectingReport.java
@@ -50,11 +50,11 @@ public class ProtectingReport extends BaseEntity {
     @Column(name = "fur_color", length = 30, nullable = false)
     private String furColor;
 
-    @Column(name = "weight", nullable = false)
-    private Float weight;
+    @Column(name = "weight", length = 10, nullable = false)
+    private String weight;
 
-    @Column(name = "age", nullable = false)
-    private Short age;
+    @Column(name = "age", length = 10, nullable = false)
+    private String age;
 
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "CHAR(1)", nullable = false)
@@ -136,7 +136,15 @@ public class ProtectingReport extends BaseEntity {
     }
 
     public String getAgeWithYear() {
-        int age = LocalDate.now().getYear() - this.age + 1;
-        return this.age + ", " + age + "살";
+        int age;
+        try{
+            int year = Integer.parseInt(this.age);
+
+            age = LocalDate.now().getYear() - year + 1;
+
+            return this.age + ", " + age + "살";
+        } catch (NumberFormatException e) {
+            return "미상";
+        }
     }
 }

--- a/src/main/java/com/kuit/findyou/domain/report/repository/ProtectingReportRepository.java
+++ b/src/main/java/com/kuit/findyou/domain/report/repository/ProtectingReportRepository.java
@@ -36,4 +36,6 @@ public interface ProtectingReportRepository extends JpaRepository<ProtectingRepo
     Long countByHappenDateEquals(LocalDate date);
 
     List<ProtectingReport> findTop10ByOrderByCreatedAtDesc();
+
+    List<ProtectingReport> findByNoticeNumberIn(List<String> noticeNumbers);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,27 +3,15 @@ spring:
     name: findyou
   profiles:
     group:
-      local : local-db, dev-port
-      dev: dev-db, dev-port
-      prod: prod-db, prod-port
+      local : local-db, dev-port, common
+      dev: dev-db, dev-port, common
+      prod: prod-db, prod-port, common
     active: dev
   mvc:
     throw-exception-if-no-handler-found: true
   web:
     resources:
       add-mappings: false
-
----
-# 공공 API serviceKey
-api:
-  serviceKey: ${SERVICE_KEY}
----
-#이미지 파일 크기 제한 조절
-spring:
-  servlet:
-    multipart:
-      max-file-size: 2MB
-      max-request-size: 2MB
 ---
 # 로컬에서 사용하는 DB
 spring:
@@ -97,10 +85,21 @@ spring:
       on-profile: prod-port
 server:
   port: 9002
-
-#S3 설정
+---
+# 공통 속성
+spring:
+  config:
+    activate:
+      on-profile: common
+  servlet:
+    multipart:     #이미지 파일 크기 제한 조절
+      max-file-size: 2MB
+      max-request-size: 2MB
 cloud:
   s3:
     bucket: findyoubucket
     access-id: ${AWS_ACCESS_KEY_ID}
     secret-key: ${AWS_SECRET_ACCESS_KEY}
+api:
+  serviceKey: ${SERVICE_KEY}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,11 @@ spring:
   web:
     resources:
       add-mappings: false
+
+---
+# 공공 API serviceKey
+api:
+  serviceKey: ${SERVICE_KEY}
 ---
 #이미지 파일 크기 제한 조절
 spring:


### PR DESCRIPTION
## Related issue 🛠
- closed #50 

## Work Description 📝
- build.gradle에 WebFlux 관련 의존성 추가
- ProtectingReport 엔티티의 weight, age 칼럼을 VARCHAR(10) 타입으로 변경
- 외부 API의 응답을 객체로 변환할 DTO 구현
- 외부 API의 응답을 엔티티화하여 DB에 저장하는 로직 구현
- DB 초기화를 위한 api 구현

## Screenshot 📸

## Uncompleted Tasks 😅
- 없습니다.

## To Reviewers 📢
구현했던 외부 API 활용 코드 올려두겠습니다.
자동으로 스케줄링이 되긴 하지만, 최초에 DB 초기화를 위해 API를 하나 만들어두었습니다.

최초에 DB를 초기화할 땐 POSTMAN 으로 값을 채워두면 될 것 같습니다.

환경변수로 설정해둔 SERVICE_KEY에 해당하는 정보는 PM님이 노션에 올려두신 것을 활용하면 됩니다.