### PR TITLE
[Fix] BaseErrorResponse 응답 형태 변경 및 Home 데이터 수정

### DIFF
--- a/src/main/java/com/kuit/findyou/domain/home/dto/HomeReportAnimalCard.java
+++ b/src/main/java/com/kuit/findyou/domain/home/dto/HomeReportAnimalCard.java
@@ -3,7 +3,7 @@ package com.kuit.findyou.domain.home.dto;
 import com.kuit.findyou.domain.report.model.Report;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Getter
 @Builder
@@ -12,7 +12,7 @@ public class HomeReportAnimalCard {
     private String thumbnailImageUrl;
     private String title;
     private String tag;
-    private LocalDateTime registerDate;
+    private LocalDate registerDate;
     private String happenLocation;
 
     public static HomeReportAnimalCard entityToDto(Report entity){
@@ -21,7 +21,7 @@ public class HomeReportAnimalCard {
                 .thumbnailImageUrl("test-image.url")
                 .title(entity.getReportAnimalBreedName())
                 .tag(entity.getTag())
-                .registerDate(entity.getCreatedAt())
+                .registerDate(entity.getCreatedAt().toLocalDate())
                 .happenLocation(entity.getEventLocation())
                 .build();
     }

--- a/src/main/java/com/kuit/findyou/global/common/response/BaseErrorResponse.java
+++ b/src/main/java/com/kuit/findyou/global/common/response/BaseErrorResponse.java
@@ -7,25 +7,25 @@ import lombok.Getter;
 import java.time.LocalDateTime;
 
 @Getter
-@JsonPropertyOrder({"success", "code", "message", "timestamp"})
+@JsonPropertyOrder({"success", "code", "message", "data"})
 public class BaseErrorResponse implements ResponseStatus {
     private final boolean success;
     private final int code;
     private final String message;
-    private final LocalDateTime timestamp;
+    private final Object data;
 
     public BaseErrorResponse(ResponseStatus status) {
         this.success = false;
         this.code = status.getCode();
         this.message = status.getMessage();
-        this.timestamp = LocalDateTime.now();
+        this.data = null;
     }
 
     public BaseErrorResponse(ResponseStatus status, String message) {
         this.success = false;
         this.code = status.getCode();
         this.message = message;
-        this.timestamp = LocalDateTime.now();
+        this.data = null;
     }
 
     @Override


### PR DESCRIPTION
## Related issue 🛠
- closed #52 

## Work Description 📝
- BaseErrorResponse의 응답 형태를 BaseResponse 와 동일하게 바꾸었습니다. 다만 data 필드가 사용될 일은 없을 것 같아 타입은 Object로 선언하고 항상 null을 반환하도록 설정했습니다.
- Home 화면에 뿌려질 HomeReportAnimalCard 의 registerDate 필드의 타입을 LocalDateTime에서 LocalDate 로 변경했습니다.

## Screenshot 📸

## Uncompleted Tasks 😅
- 없습니다

## To Reviewers 📢
