### PR TITLE
[Fix] 조회시 축종 필터링 방식 변경

### DIFF
--- a/src/main/java/com/kuit/findyou/domain/report/repository/ProtectingReportRepository.java
+++ b/src/main/java/com/kuit/findyou/domain/report/repository/ProtectingReportRepository.java
@@ -21,7 +21,7 @@ public interface ProtectingReportRepository extends JpaRepository<ProtectingRepo
             "WHERE pr.id < :id " +
             "AND (:startDate IS NULL OR pr.happenDate >= :startDate) " +
             "AND (:endDate IS NULL OR pr.happenDate <= :endDate) " +
-            "AND (:species IS NULL OR pr.species = :species) " +
+            "AND (:species IS NULL OR pr.species LIKE CONCAT('%', :species, '%')) " +
             "AND (:breeds IS NULL OR pr.breed IN :breeds) " +
             "AND (:location IS NULL OR pr.authority LIKE CONCAT('%', :location, '%'))" +
             "ORDER BY pr.id DESC")

--- a/src/main/java/com/kuit/findyou/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/kuit/findyou/domain/report/repository/ReportRepository.java
@@ -25,7 +25,7 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
     "WHERE r.id < :id " +
     "AND (:startDate IS NULL OR r.eventDate >= :startDate) " +
     "AND (:endDate IS NULL OR r.eventDate <= :endDate) " +
-    "AND (:species IS NULL OR r.reportAnimal.breed.species = :species) " +
+    "AND (:species IS NULL OR r.reportAnimal.breed.species LIKE CONCAT('%', :species, '%')) " +
     "AND (:breeds IS NULL OR r.reportAnimal.breed.name IN :breeds) " +
     "AND (:location IS NULL OR r.eventLocation LIKE CONCAT('%', :location, '%'))" +
     "ORDER BY r.id DESC")


### PR DESCRIPTION
## Related issue 🛠
- closed #66 

## Work Description 📝
- 필터링 방식을 변경하였습니다.
- 축종 정보로 '기타' 만 들어와도 '기타축종' 을 조회할 수 있도록 하기 위해 '기타'라는 부분 문자열을 포함하는 축종 정보를 지니는 데이터를 필터링 하도록 변경하였습니다.

## Screenshot 📸

## Uncompleted Tasks 😅
- 없습니다.

## To Reviewers 📢
