### PR TITLE
[Feat] 품종 정보 반환 및 품종 체크 로직 구현

### DIFF
--- a/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
+++ b/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
@@ -5,6 +5,7 @@ import com.kuit.findyou.domain.report.service.*;
 import com.kuit.findyou.global.common.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -22,6 +23,7 @@ public class ReportController {
     private final AnimalRetrieveService animalRetrieveService;
     private final MissingReportPostService missingReportPostService;
     private final GetAllBreedsService getAllBreedsService;
+    private final BreedValidateService breedValidateService;
 
     // test에 필요한 레포지토리들
 //    private final UserRepository userRepository;
@@ -97,6 +99,11 @@ public class ReportController {
     @GetMapping("/breeds")
     public BaseResponse<List<BreedResponseDTO>> getAllBreeds() {
         return new BaseResponse<>(getAllBreedsService.getAllBreeds());
+    }
+
+    @GetMapping("/breeds/validation")
+    public BaseResponse<BreedValidateResponseDTO> validateBreed(@RequestParam String breedName) {
+        return new BaseResponse<>(breedValidateService.validateBreed(breedName));
     }
 
 //    @PostConstruct

--- a/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
+++ b/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
@@ -3,6 +3,8 @@ package com.kuit.findyou.domain.report.controller;
 import com.kuit.findyou.domain.report.dto.*;
 import com.kuit.findyou.domain.report.service.*;
 import com.kuit.findyou.global.common.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.validation.annotation.Validated;
@@ -96,13 +98,17 @@ public class ReportController {
         return new BaseResponse<>(null);
     }
 
+    @Operation(summary = "품종 전체 반환", description = "모든 품종 정보를 반환합니다.")
     @GetMapping("/breeds")
     public BaseResponse<List<BreedResponseDTO>> getAllBreeds() {
         return new BaseResponse<>(getAllBreedsService.getAllBreeds());
     }
 
+    @Operation(summary = "품종 검증", description = "입력으로 전달된 품종이 DB에 존재하는지 검증합니다.")
     @GetMapping("/breeds/validation")
-    public BaseResponse<BreedValidateResponseDTO> validateBreed(@RequestParam String breedName) {
+    public BaseResponse<BreedValidateResponseDTO> validateBreed(
+            @Parameter(required = true, description = "DB에 존재하는 지 검증할 품종")
+            @RequestParam String breedName) {
         return new BaseResponse<>(breedValidateService.validateBreed(breedName));
     }
 

--- a/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
+++ b/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
@@ -1,27 +1,14 @@
 package com.kuit.findyou.domain.report.controller;
 
-import com.kuit.findyou.domain.auth.model.User;
-import com.kuit.findyou.domain.auth.repository.UserRepository;
 import com.kuit.findyou.domain.report.dto.*;
-import com.kuit.findyou.domain.report.model.*;
-import com.kuit.findyou.domain.report.repository.*;
 import com.kuit.findyou.domain.report.service.*;
-import com.kuit.findyou.global.common.exception.BadRequestException;
-import com.kuit.findyou.global.common.response.BaseErrorResponse;
 import com.kuit.findyou.global.common.response.BaseResponse;
-import com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus;
-import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
-
-import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.ALREADY_SAVED_INTEREST_REPORT;
-import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.BAD_REQUEST;
 
 @RestController
 @RequestMapping("/api/v1/reports")
@@ -34,6 +21,7 @@ public class ReportController {
     private final ReportAnimalRetrieveService reportAnimalRetrieveService;
     private final AnimalRetrieveService animalRetrieveService;
     private final MissingReportPostService missingReportPostService;
+    private final GetAllBreedsService getAllBreedsService;
 
     // test에 필요한 레포지토리들
 //    private final UserRepository userRepository;
@@ -104,6 +92,11 @@ public class ReportController {
     public BaseResponse<Void> postMissingReport(@RequestBody MissingReportDTO requestDTO) {
         missingReportPostService.createReport(requestDTO);
         return new BaseResponse<>(null);
+    }
+
+    @GetMapping("/breeds")
+    public BaseResponse<List<BreedResponseDTO>> getAllBreeds() {
+        return new BaseResponse<>(getAllBreedsService.getAllBreeds());
     }
 
 //    @PostConstruct

--- a/src/main/java/com/kuit/findyou/domain/report/dto/BreedResponseDTO.java
+++ b/src/main/java/com/kuit/findyou/domain/report/dto/BreedResponseDTO.java
@@ -1,0 +1,19 @@
+package com.kuit.findyou.domain.report.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class BreedResponseDTO {
+
+    private Long breedId;
+
+    private String breedName;
+
+    private String species;
+
+}

--- a/src/main/java/com/kuit/findyou/domain/report/dto/BreedValidateResponseDTO.java
+++ b/src/main/java/com/kuit/findyou/domain/report/dto/BreedValidateResponseDTO.java
@@ -1,0 +1,15 @@
+package com.kuit.findyou.domain.report.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BreedValidateResponseDTO {
+
+    private Long breedId;
+
+    private Boolean isExist;
+}

--- a/src/main/java/com/kuit/findyou/domain/report/repository/BreedRepository.java
+++ b/src/main/java/com/kuit/findyou/domain/report/repository/BreedRepository.java
@@ -2,8 +2,18 @@ package com.kuit.findyou.domain.report.repository;
 
 import com.kuit.findyou.domain.report.model.Breed;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface BreedRepository extends JpaRepository<Breed, Long> {
+
+    @Query("SELECT b " +
+            "FROM Breed b " +
+            "WHERE REPLACE(TRIM(b.name), ' ', '') = REPLACE(TRIM(:breedName), ' ', '')")
+    Optional<Breed> findByTrimmedBreedName(@Param("breedName") String breedName);
+
 }

--- a/src/main/java/com/kuit/findyou/domain/report/service/BreedValidateService.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/BreedValidateService.java
@@ -1,0 +1,31 @@
+package com.kuit.findyou.domain.report.service;
+
+import com.kuit.findyou.domain.report.dto.BreedValidateResponseDTO;
+import com.kuit.findyou.domain.report.model.Breed;
+import com.kuit.findyou.domain.report.repository.BreedRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BreedValidateService {
+
+    private final BreedRepository breedRepository;
+
+    public BreedValidateResponseDTO validateBreed(String breedName) {
+        Breed findBreed = breedRepository.findByTrimmedBreedName(breedName)
+                .orElse(null);
+
+        if(findBreed == null) {
+            return BreedValidateResponseDTO.builder()
+                    .breedId(-1L)
+                    .isExist(false)
+                    .build();
+        }
+
+        return BreedValidateResponseDTO.builder()
+                .breedId(findBreed.getId())
+                .isExist(true)
+                .build();
+    }
+}

--- a/src/main/java/com/kuit/findyou/domain/report/service/GetAllBreedsService.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/GetAllBreedsService.java
@@ -1,0 +1,26 @@
+package com.kuit.findyou.domain.report.service;
+
+import com.kuit.findyou.domain.report.dto.BreedResponseDTO;
+import com.kuit.findyou.domain.report.repository.BreedRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class GetAllBreedsService {
+
+    private final BreedRepository breedRepository;
+
+    public List<BreedResponseDTO> getAllBreeds() {
+        return breedRepository.findAll().stream()
+                .map(breed -> BreedResponseDTO.builder()
+                        .breedId(breed.getId())
+                        .breedName(breed.getName())
+                        .species(breed.getSpecies())
+                        .build())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/kuit/findyou/global/common/exception_handler/GlobalControllerAdvice.java
+++ b/src/main/java/com/kuit/findyou/global/common/exception_handler/GlobalControllerAdvice.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.tomcat.util.http.fileupload.FileUploadException;
 import org.hibernate.TypeMismatchException;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -23,7 +24,7 @@ import static com.kuit.findyou.global.common.response.status.BaseExceptionRespon
 public class GlobalControllerAdvice {
     // 잘못된 요청일 경우
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @ExceptionHandler({BadRequestException.class, TypeMismatchException.class})
+    @ExceptionHandler({BadRequestException.class, TypeMismatchException.class, MissingServletRequestParameterException.class})
     public BaseErrorResponse handle_BadRequest(Exception e){
         log.error("[handle_BadRequest]", e);
         return new BaseErrorResponse(BAD_REQUEST);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,7 +46,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## Related issue 🛠
- closed #68 

## Work Description 📝
- 품종 정보를 DB에서 반환하는 로직을 구현하였습니다.
- gpt로부터 응답받은 품종 정보가 유효한지, DB에 존재하는지 검증하는 로직을 구현하였습니다. 이 때, 공백을 모두 삭제하고 검증하도록 구현하였습니다.
- 간단한 Swagger 명세도 추가하였습니다.

## Screenshot 📸

## Uncompleted Tasks 😅
- 없습니다.

## To Reviewers 📢
