### PR TITLE
[Refactor] 이미지 업로드 파일 용량 초과 관련 에러 추가

### DIFF
--- a/src/main/java/com/kuit/findyou/global/common/exception_handler/GlobalControllerAdvice.java
+++ b/src/main/java/com/kuit/findyou/global/common/exception_handler/GlobalControllerAdvice.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.multipart.MultipartException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
@@ -76,5 +77,12 @@ public class GlobalControllerAdvice {
     public BaseErrorResponse handle_MultipartException(MultipartException e) {
         log.error("[handle_MultipartException]", e);
         return new BaseErrorResponse(BAD_REQUEST);
+    }
+
+    @ResponseStatus(HttpStatus.PAYLOAD_TOO_LARGE)
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public BaseErrorResponse handle_MaxUploadSizeExceeded(MaxUploadSizeExceededException e) {
+        log.error("[handle_MaxUploadSizeExceeded]", e);
+        return new BaseErrorResponse(UPLOAD_SIZE_EXCEEDED, "파일 크기가 허용된 최대 크기(2MB)를 초과했습니다.업로드할 파일 크기를 확인해 주세요.");
     }
 }

--- a/src/main/java/com/kuit/findyou/global/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/kuit/findyou/global/common/response/status/BaseExceptionResponseStatus.java
@@ -13,6 +13,9 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     NO_FILE_UPLOADED(40001, "업로드된 파일이 없습니다."),
     UPLOAD_ERROR(50001, "파일 업로드 중 에러가 발생했습니다."),
     IMAGE_NOT_FOUND(40400, "해당 URL의 이미지를 찾을 수 없습니다"),
+    UPLOAD_SIZE_EXCEEDED(40000, "파일 크기가 최대 허용 용량(2MB)을 초과했습니다."),
+
+
 
     //게시글 등록 관련 에러
     BREED_NOT_FOUND(40000,"존재하지 않는 품종입니다"),


### PR DESCRIPTION
## Related issue 🛠
- closed #88 

## Work Description 📝
- GlobalControllerAdvice 수정
## Screenshot 📸
![image](https://github.com/user-attachments/assets/4fdc77d0-dd0e-414d-b7ec-04b2c754dd2e)

## Uncompleted Tasks 😅

## To Reviewers 📢
이미지 업로드 시 파일 용량이 설정해 둔 2MB를 초과할 경우, 에러 처리가 미흡했습니다.  ( 에러 응답을 보내주긴 하지만, 용량초과 때문이라는 것을 인지하기 힘들 것 같아 추가했습니다 ) 
ImageControllerAdvice에 추가하고자 하였는데, 예외가 DispatcherServlet에 도달하기 전에 처리되는 문제가 있어서 GlobalControllerAdvice에 추가하였습니다