### PR TITLE
[Refactor] 토큰으로부터 userId 받아와 서비스 로직에 적용 

### DIFF
--- a/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
+++ b/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
@@ -129,8 +129,8 @@ public class ReportController {
             description = "목격 신고, 실종 신고 게시글을 삭제합니다."
     )
     @DeleteMapping("/{report_id}")
-    public BaseResponse<Void> deleteReport(@PathVariable("report_id") Long reportId) {
-        reportDeleteService.deleteReport(reportId);
+    public BaseResponse<Void> deleteReport(@PathVariable("report_id") Long reportId, @LoginUserId Long userId) {
+        reportDeleteService.deleteReport(reportId, userId);
         return new BaseResponse<>(null);
     }
 

--- a/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
+++ b/src/main/java/com/kuit/findyou/domain/report/controller/ReportController.java
@@ -4,6 +4,7 @@ import com.kuit.findyou.domain.report.dto.request.*;
 import com.kuit.findyou.domain.report.dto.response.*;
 import com.kuit.findyou.domain.report.service.*;
 import com.kuit.findyou.global.common.response.BaseResponse;
+import com.kuit.findyou.global.jwt.annotation.LoginUserId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
@@ -110,8 +111,8 @@ public class ReportController {
             description = "실종 신고 게시글을 등록합니다."
     )
     @PostMapping("/new-missing-reports")
-    public BaseResponse<Void> postMissingReport(@RequestBody MissingReportDTO requestDTO) {
-        missingReportPostService.createReport(requestDTO);
+    public BaseResponse<Void> postMissingReport(@RequestBody MissingReportDTO requestDTO, @LoginUserId Long userId) {
+        missingReportPostService.createReport(requestDTO, userId);
         return new BaseResponse<>(null);
     }
     @Operation(
@@ -119,8 +120,8 @@ public class ReportController {
             description = "목격 신고 게시글을 등록합니다."
     )
     @PostMapping("/new-witness-reports")
-    public BaseResponse<Void> postWitnessReport(@RequestBody WitnessReportDTO requestDTO) {
-        witnessReportPostService.createReport(requestDTO);
+    public BaseResponse<Void> postWitnessReport(@RequestBody WitnessReportDTO requestDTO, @LoginUserId Long userId) {
+        witnessReportPostService.createReport(requestDTO, userId);
         return new BaseResponse<>(null);
     }
     @Operation(

--- a/src/main/java/com/kuit/findyou/domain/report/dto/request/MissingReportDTO.java
+++ b/src/main/java/com/kuit/findyou/domain/report/dto/request/MissingReportDTO.java
@@ -27,6 +27,4 @@ public class MissingReportDTO {
     private String description;
     @Schema(description = "실종 날짜" , example = "2025-02-07")
     private LocalDate missingDate;
-    @Schema(description = "유저 ID")
-    private Long userId;
 }

--- a/src/main/java/com/kuit/findyou/domain/report/dto/request/WitnessReportDTO.java
+++ b/src/main/java/com/kuit/findyou/domain/report/dto/request/WitnessReportDTO.java
@@ -27,6 +27,4 @@ public class WitnessReportDTO {
     private String description;
     @Schema(description = "목격 날짜" , example = "2025-02-07")
     private LocalDate foundDate;
-    @Schema(description = "유저 ID")
-    private Long userId;
 }

--- a/src/main/java/com/kuit/findyou/domain/report/service/MissingReportPostService.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/MissingReportPostService.java
@@ -32,8 +32,8 @@ public class MissingReportPostService {
 
 
     @Transactional
-    public void createReport(MissingReportDTO requestDTO) throws ReportCreationException {
-        User user = userRepository.findById(requestDTO.getUserId()).orElseThrow(() -> new ReportCreationException(BaseExceptionResponseStatus.USER_NOT_FOUND));
+    public void createReport(MissingReportDTO requestDTO, Long userId) throws ReportCreationException {
+        User user = userRepository.findById(userId).orElseThrow(() -> new ReportCreationException(BaseExceptionResponseStatus.USER_NOT_FOUND));
         Breed breed = breedRepository.findById(requestDTO.getBreed()).orElseThrow(() -> new ReportCreationException(BaseExceptionResponseStatus.BREED_NOT_FOUND));
         List<AnimalFeature> features = animalFeatureRepository.findAllById(requestDTO.getFeatures());
 

--- a/src/main/java/com/kuit/findyou/domain/report/service/ReportDeleteService.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/ReportDeleteService.java
@@ -3,7 +3,10 @@ package com.kuit.findyou.domain.report.service;
 import com.kuit.findyou.domain.report.exception.ReportCreationException;
 import com.kuit.findyou.domain.report.model.Report;
 import com.kuit.findyou.domain.report.repository.ReportRepository;
+import com.kuit.findyou.domain.user.model.User;
+import com.kuit.findyou.domain.user.repository.UserRepository;
 import com.kuit.findyou.global.common.exception.ReportNotFoundException;
+import com.kuit.findyou.global.common.exception.UserNotFoundException;
 import com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,15 +15,20 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ReportDeleteService {
     private final ReportRepository reportRepository;
+    private final UserRepository userRepository;
 
-
-    public void deleteReport(Long reportId) throws ReportNotFoundException {
+    public void deleteReport(Long reportId, Long userId) throws ReportNotFoundException {
 
         Report report = reportRepository.findById(reportId)
                 .orElseThrow(() -> new ReportCreationException(BaseExceptionResponseStatus.REPORT_NOT_FOUND));
 
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(BaseExceptionResponseStatus.USER_NOT_FOUND));
+
+        //토큰과 일치하는지 확인
+        if(!report.getUser().getId().equals(userId)) {
+            throw new UserNotFoundException(BaseExceptionResponseStatus.UNAUTHORIZED_USER_ID);
+        }
         reportRepository.delete(report);
-
-
     }
 }

--- a/src/main/java/com/kuit/findyou/domain/report/service/WitnessReportPostService.java
+++ b/src/main/java/com/kuit/findyou/domain/report/service/WitnessReportPostService.java
@@ -30,8 +30,8 @@ public class WitnessReportPostService {
     private final ImageRepository imageRepository;
 
     @Transactional
-    public void createReport(WitnessReportDTO requestDTO) throws ReportCreationException {
-        User user = userRepository.findById(requestDTO.getUserId()).orElseThrow(() -> new ReportCreationException(BaseExceptionResponseStatus.USER_NOT_FOUND));
+    public void createReport(WitnessReportDTO requestDTO, Long userId) throws ReportCreationException {
+        User user = userRepository.findById(userId).orElseThrow(() -> new ReportCreationException(BaseExceptionResponseStatus.USER_NOT_FOUND));
         Breed breed = breedRepository.findById(requestDTO.getBreed()).orElseThrow(() -> new ReportCreationException(BaseExceptionResponseStatus.BREED_NOT_FOUND));
         List<AnimalFeature> features = animalFeatureRepository.findAllById(requestDTO.getFeatures());
 

--- a/src/main/java/com/kuit/findyou/global/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/kuit/findyou/global/common/response/status/BaseExceptionResponseStatus.java
@@ -14,10 +14,11 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     IMAGE_NOT_FOUND(40400, "해당 URL의 이미지를 찾을 수 없습니다"),
     UPLOAD_SIZE_EXCEEDED(40000, "파일 크기가 최대 허용 용량(2MB)을 초과했습니다."),
 
-
-
     //게시글 등록 관련 에러
     BREED_NOT_FOUND(40000,"존재하지 않는 품종입니다"),
+
+    //게시글 삭제 관련 에러
+    UNAUTHORIZED_USER_ID(40100, "토큰과 게시글 UserId가 일치하지 않습니다."),
 
     // 관심글 등록 관련 에러
     USER_NOT_FOUND(40000, "존재하지 않는 유저입니다."),
@@ -36,6 +37,8 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
 
     SAME_USER_EMAIL_EXISTS(40000, "이미 존재하는 이메일입니다."),
     INTERNAL_SERVER_ERROR(50000, "서버 내부 오류입니다.");
+
+
 
     private final boolean success = false;
     private final int code;

--- a/src/main/java/com/kuit/findyou/global/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/kuit/findyou/global/common/response/status/BaseExceptionResponseStatus.java
@@ -18,7 +18,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     BREED_NOT_FOUND(40000,"존재하지 않는 품종입니다"),
 
     //게시글 삭제 관련 에러
-    UNAUTHORIZED_USER_ID(40100, "토큰과 게시글 UserId가 일치하지 않습니다."),
+    UNAUTHORIZED_USER_ID(40100, "로그인 한 유저가 작성한 게시물이 아닙니다."),
 
     // 관심글 등록 관련 에러
     USER_NOT_FOUND(40000, "존재하지 않는 유저입니다."),


### PR DESCRIPTION
## Related issue 🛠
- closed #99 

## Work Description 📝
- 게시글 등록 로직에서 userId를 토큰으로부터 받아오도록 수정하였습니다. 
- 게시글 삭제 요청 시 게시글의 userId와 토큰으로부터 받아온 userId가 같은지 확인 후, 다르면 예외처리 하였습니다.

## Screenshot 📸

## Uncompleted Tasks 😅

## To Reviewers 📢
