### PR TITLE
[Fix] cardId를 가지고 관심동물 해제를 수행하도록 로직을 수정

### DIFF
--- a/src/main/java/com/kuit/findyou/domain/auth/dto/SignupRequest.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/dto/SignupRequest.java
@@ -15,6 +15,6 @@ public class SignupRequest {
     private String password;
 
     @NotBlank
-    @Length(max = 8, message = "비밀번호는 최대 8자입니다.")
+    @Length(max = 8, message = "닉네임은 최대 8자입니다.")
     private String nickname;
 }

--- a/src/main/java/com/kuit/findyou/domain/report/repository/InterestProtectingReportRepository.java
+++ b/src/main/java/com/kuit/findyou/domain/report/repository/InterestProtectingReportRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface InterestProtectingReportRepository extends JpaRepository<InterestProtectingReport, Long> {
@@ -15,4 +16,6 @@ public interface InterestProtectingReportRepository extends JpaRepository<Intere
     Slice<InterestProtectingReport> findAllByIdLessThanAndUserId(Long id, Long userId, Pageable pageable);
 
     List<InterestProtectingReport> findAllByUserId(Long userId);
+
+    Optional<InterestProtectingReport> findByUserIdAndProtectingReportId(Long UserId, Long protectingReportId);
 }

--- a/src/main/java/com/kuit/findyou/domain/report/repository/InterestReportRepository.java
+++ b/src/main/java/com/kuit/findyou/domain/report/repository/InterestReportRepository.java
@@ -8,9 +8,13 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface InterestReportRepository extends JpaRepository<InterestReport, Long> {
     boolean existsByUserAndReport(User user, Report report);
 
     Slice<InterestReport> findAllByIdLessThanAndUserId(Long lastProtectId, Long userId, PageRequest of);
+
+    Optional<InterestReport> findByUserIdAndReportId(Long userId, Long reportId);
 }

--- a/src/main/java/com/kuit/findyou/domain/user/controller/UserController.java
+++ b/src/main/java/com/kuit/findyou/domain/user/controller/UserController.java
@@ -97,11 +97,11 @@ public class UserController {
             summary = "관심동물 삭제 - 신고동물 삭제 ",
             description = "신고동물을 관심동물에서 삭제하는 api입니다. "
     )
-    @Parameter(name = "report_animal_id", description = "삭제할 관심동물의 id")
-    @DeleteMapping("interest-animals/report-animals/{report_animal_id}")
+    @Parameter(name = "report_id", description = "삭제할 관심동물의 id")
+    @DeleteMapping("interest-animals/report-animals/{report_id}")
     public BaseResponse<Object> deleteInterestReportAnimal(
             @LoginUserId Long userId,
-            @PathVariable("report_animal_id") Long reportId
+            @PathVariable("report_id") Long reportId
     ){
         log.info("[deleteInterestReportAnimal] id = {}", reportId);
         userService.removeInterestReportAnimal(userId, reportId);

--- a/src/main/java/com/kuit/findyou/domain/user/controller/UserController.java
+++ b/src/main/java/com/kuit/findyou/domain/user/controller/UserController.java
@@ -83,13 +83,13 @@ public class UserController {
             description = "보호중동물을 관심동물에서 삭제하는 api입니다. "
     )
     @Parameter(name = "interest_protecting_animal_id", description = "삭제할 관심동물의 id")
-    @DeleteMapping("interest-animals/protecting-animals/{interest_protecting_animal_id}")
+    @DeleteMapping("interest-animals/protecting-animals/{protecting_report_id}")
     public BaseResponse<Object> deleteInterestProtectingAnimal(
             @LoginUserId Long userId,
-            @PathVariable("interest_protecting_animal_id") Long interestProtectingReportId
+            @PathVariable("protecting_report_id") Long protectingReportId
     ){
-        log.info("[deleteInterestProtectingAnimal] interestProtectingReportId = {}", interestProtectingReportId);
-        userService.removeInterestProtectingAnimal(userId, interestProtectingReportId);
+        log.info("[deleteInterestProtectingAnimal] interestProtectingReportId = {}", protectingReportId);
+        userService.removeInterestProtectingAnimal(userId, protectingReportId);
         return new BaseResponse<>(null);
     }
 

--- a/src/main/java/com/kuit/findyou/domain/user/service/UserService.java
+++ b/src/main/java/com/kuit/findyou/domain/user/service/UserService.java
@@ -114,8 +114,8 @@ public class UserService {
         interestProtectingReportRepository.delete(interest);
     }
 
-    public void removeInterestReportAnimal(Long userId, Long interestId) {
-        InterestReport interest = interestReportRepository.findById(interestId).orElseThrow(() -> new InterestAnimalNotFoundException(INTEREST_ANIMAL_NOT_FOUND));
+    public void removeInterestReportAnimal(Long userId, Long reportId) {
+        InterestReport interest = interestReportRepository.findByUserIdAndReportId(userId, reportId).orElseThrow(() -> new InterestAnimalNotFoundException(INTEREST_ANIMAL_NOT_FOUND));
         if(interest.getUser().getId() != userId){
             throw new UnauthorizedUserException(UNAUTHORIZED_USER);
         }

--- a/src/main/java/com/kuit/findyou/domain/user/service/UserService.java
+++ b/src/main/java/com/kuit/findyou/domain/user/service/UserService.java
@@ -103,8 +103,8 @@ public class UserService {
         return interestProtectingReportRepository.existsByUserIdAndProtectingReportId(userId, protectingReportId);
     }
 
-    public void removeInterestProtectingAnimal(Long userId, Long interestId) {
-        InterestProtectingReport interest = interestProtectingReportRepository.findById(interestId).orElseThrow(() -> new InterestAnimalNotFoundException(INTEREST_ANIMAL_NOT_FOUND));
+    public void removeInterestProtectingAnimal(Long userId, Long protectingReportId) {
+        InterestProtectingReport interest = interestProtectingReportRepository.findByUserIdAndProtectingReportId(userId, protectingReportId).orElseThrow(() -> new InterestAnimalNotFoundException(INTEREST_ANIMAL_NOT_FOUND));
         if (interest.getUser().getId() != userId){
             throw new UnauthorizedUserException(UNAUTHORIZED_USER);
         }

--- a/src/test/java/com/kuit/findyou/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/kuit/findyou/domain/user/service/UserServiceTest.java
@@ -235,13 +235,13 @@ public class UserServiceTest {
         Long savedInterestId3 = userService.saveInterestReportAnimal(savedUserId, request3);
 
         // when
-        userService.removeInterestReportAnimal(savedUserId, savedInterestId2);
+        userService.removeInterestReportAnimal(savedUserId, savedReport3.getId());
 
         em.flush();
         em.clear();
 
 
-        Optional<InterestReport> interestReportById = interestReportRepository.findById(savedInterestId2);
+        Optional<InterestReport> interestReportById = interestReportRepository.findByUserIdAndReportId(savedUserId, savedReport3.getId());
         Optional<User> userById = userRepository.findById(savedUserId);
 
         // then


### PR DESCRIPTION
## Related issue 🛠
- closed #100

## Work Description 📝
- 명세서대로 보호중동물의 id와 신고동물의 id로 관심동물을 해제하도록 로직을 수정했습니다

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
- 없습니다

## To Reviewers 📢
