### PR TITLE
[Feat] 회원가입 완료 시 엑세스토큰 발행하도록 구현, 그 외에 추가 작업 수행

### DIFF
--- a/src/main/java/com/kuit/findyou/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/controller/AuthController.java
@@ -5,6 +5,8 @@ import com.kuit.findyou.domain.auth.dto.CheckDuplicateEmailResponse;
 import com.kuit.findyou.domain.auth.dto.SignupRequest;
 import com.kuit.findyou.domain.auth.service.UserSignupService;
 import com.kuit.findyou.global.common.response.BaseResponse;
+import com.kuit.findyou.global.jwt.util.JwtUtil;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class AuthController {
     private final UserSignupService userSignupService;
+    private final JwtUtil jwtUtil;
 
     @GetMapping("test")
     public BaseResponse<String> test(){
@@ -23,9 +26,11 @@ public class AuthController {
     }
 
     @PostMapping("signup")
-    public BaseResponse<Void> signup(@RequestBody @Valid SignupRequest request){
+    public BaseResponse<Void> signup(@RequestBody @Valid SignupRequest request, HttpServletResponse response){
         log.info("[signup] email = {} password = {}", request.getEmail(), request.getPassword());
-        userSignupService.signup(request);
+        Long userId = userSignupService.signup(request);
+        String accessToken = jwtUtil.createAccessJwt(userId);
+        response.setHeader("Authorization", "Bearer " + accessToken);
         return new BaseResponse<>(null);
     }
 

--- a/src/main/java/com/kuit/findyou/domain/auth/exception_handler/AuthControllerAdvice.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/exception_handler/AuthControllerAdvice.java
@@ -3,6 +3,8 @@ package com.kuit.findyou.domain.auth.exception_handler;
 import com.kuit.findyou.domain.auth.exception.SameUserEmailExistsException;
 import com.kuit.findyou.global.common.response.BaseErrorResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import static com.kuit.findyou.global.common.response.status.BaseExceptionResponseStatus.*;
 
 @Slf4j
+@Order(Ordered.HIGHEST_PRECEDENCE)
 @RestControllerAdvice
 public class AuthControllerAdvice {
     // 같은 이메일로 가입한 유저가 존재하는 경우

--- a/src/main/java/com/kuit/findyou/domain/auth/service/UserSignupService.java
+++ b/src/main/java/com/kuit/findyou/domain/auth/service/UserSignupService.java
@@ -5,6 +5,7 @@ import com.kuit.findyou.domain.auth.dto.SignupRequest;
 import com.kuit.findyou.domain.auth.exception.SameUserEmailExistsException;
 import com.kuit.findyou.domain.user.model.User;
 import com.kuit.findyou.domain.user.repository.UserRepository;
+import com.kuit.findyou.global.jwt.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -18,7 +19,7 @@ import static com.kuit.findyou.global.common.response.status.BaseExceptionRespon
 public class UserSignupService {
     private final UserRepository userRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
-    public void signup(SignupRequest request) {
+    public Long signup(SignupRequest request) {
         String email = request.getEmail();
         String password = request.getPassword();
         String nickname = request.getNickname();
@@ -31,7 +32,8 @@ public class UserSignupService {
                 .email(email)
                 .password(bCryptPasswordEncoder.encode(password))
                 .build();
-        userRepository.save(newUser);
+        User savedUser = userRepository.save(newUser);
+        return savedUser.getId();
     }
 
     private boolean alreadyExistentUser(String email) {

--- a/src/test/java/com/kuit/findyou/domain/report/service/MissingReportPostServiceTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/service/MissingReportPostServiceTest.java
@@ -85,7 +85,6 @@ public class MissingReportPostServiceTest {
         AnimalFeature animalFeature2 = animalFeatureRepository.findById(2L).get();
 
         MissingReportDTO dto = MissingReportDTO.builder()
-                .userId(user.getId())
                 .breed(breed.getId())
                 .sex("M")
                 .furColor(Arrays.asList("갈색"))
@@ -96,7 +95,7 @@ public class MissingReportPostServiceTest {
                 .imageUrls(Arrays.asList("s3://findyoubucket/0066a3a2-85de-46fb-8ea8-501cfcf74074.jpg", "s3://findyoubucket/062d2851-0294-4e3a-b87b-3952a783bacd"))
                 .build();
 
-        missingReportPostService.createReport(dto);
+        missingReportPostService.createReport(dto, user.getId());
 
         em.flush();
         //em.clear();

--- a/src/test/java/com/kuit/findyou/domain/report/service/ReportDeleteTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/service/ReportDeleteTest.java
@@ -102,7 +102,7 @@ public class ReportDeleteTest {
 
     @Test
     void deleteReport_Success() {
-        reportDeleteService.deleteReport(report.getId());
+        reportDeleteService.deleteReport(report.getId(), user.getId());
 
         // 삭제 후 데이터베이스에서 해당 객체가 없는지 확인
         assertThat(reportRepository.findById(report.getId())).isEmpty();

--- a/src/test/java/com/kuit/findyou/domain/report/service/WitnessReportPostServiceTest.java
+++ b/src/test/java/com/kuit/findyou/domain/report/service/WitnessReportPostServiceTest.java
@@ -81,7 +81,6 @@ public class WitnessReportPostServiceTest {
         AnimalFeature animalFeature2 = animalFeatureRepository.findById(2L).get();
 
         WitnessReportDTO dto = WitnessReportDTO.builder()
-                .userId(user.getId())
                 .breed(breed.getId())
                 .sex("M")
                 .furColor(Arrays.asList("갈색"))
@@ -92,7 +91,7 @@ public class WitnessReportPostServiceTest {
                 .imageUrls(Arrays.asList("s3://findyoubucket/0066a3a2-85de-46fb-8ea8-501cfcf74074.jpg", "s3://findyoubucket/062d2851-0294-4e3a-b87b-3952a783bacd"))
                 .build();
 
-        witnessReportPostService.createReport(dto);
+        witnessReportPostService.createReport(dto, user.getId());
 
         em.flush();
         //em.clear();


### PR DESCRIPTION
## Related issue 🛠
- closed #104 

## Work Description 📝
- 회원가입 완료 시 엑세스토큰을 받을 수 있도록 구현했습니다. 추가로 이전 이슈에서 미해결된 작업을 추가로 수행했습니다. DTO 변경에 따라 테스트코드를 수정하고, auth 컨트롤러 어드바이스의 우선순위가 지정되지 않았어서 이를 지정해주었습니다.

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
- 없습니다

## To Reviewers 📢
